### PR TITLE
HCD: relax HCD_RemoveDevice teardown asserts to logged best-effort cleanup

### DIFF
--- a/USBDDOS/HCD/hcd.c
+++ b/USBDDOS/HCD/hcd.c
@@ -87,21 +87,25 @@ BOOL HCD_RemoveDevice(HCD_Device* pDevice)
 
     assert(pDevice->pRequest == NULL);
 
-    BOOL result = pDevice->pHub->SetPortStatus(pDevice->pHub, pDevice->bHubPort, USB_PORT_RESET); //No need to do that, but do it for safety
-    assert(result);
-    result = result && pDevice->pHub->SetPortStatus(pDevice->pHub, pDevice->bHubPort, USB_PORT_DISABLE);
-    assert(result);
-    result = result && pDevice->pHCI->pHCDMethod->RemoveDevice(pDevice);
-    assert(result);
+    //Best-effort cleanup. SetPortStatus/HCDMethod failures during teardown are logged
+    //but not fatal: the device must be removed from the HCD DeviceList regardless, or
+    //subsequent enumeration sees a stale entry and triggers worse misbehavior. Each
+    //step runs unconditionally so a failure early in the chain doesn't skip later steps.
+    BOOL portReset = pDevice->pHub->SetPortStatus(pDevice->pHub, pDevice->bHubPort, USB_PORT_RESET); //No need to do that, but do it for safety
+    if(!portReset) _LOG("HCD_RemoveDevice: port %d reset failed during teardown\n", pDevice->bHubPort);
+    BOOL portDisable = pDevice->pHub->SetPortStatus(pDevice->pHub, pDevice->bHubPort, USB_PORT_DISABLE);
+    if(!portDisable) _LOG("HCD_RemoveDevice: port %d disable failed during teardown\n", pDevice->bHubPort);
+    BOOL hcdRemove = pDevice->pHCI->pHCDMethod->RemoveDevice(pDevice);
+    if(!hcdRemove) _LOG("HCD_RemoveDevice: HCI method RemoveDevice failed during teardown\n");
 
-    if(result)
-    {
-        memmove(&pDevice->pHCI->DeviceList[i],&pDevice->pHCI->DeviceList[i+1],(pDevice->pHCI->bDevCount-i-1)*sizeof(HCD_Device*));
-        pDevice->pHCI->DeviceList[--pDevice->pHCI->bDevCount] = NULL;
-        pDevice->pHCData = NULL;
-        pDevice->pHCI = NULL;
-    }
-    return result;
+    //Always remove from device list — even if some cleanup steps failed.
+    //Leaving a half-removed device in the list is strictly worse than partial cleanup.
+    memmove(&pDevice->pHCI->DeviceList[i],&pDevice->pHCI->DeviceList[i+1],(pDevice->pHCI->bDevCount-i-1)*sizeof(HCD_Device*));
+    pDevice->pHCI->DeviceList[--pDevice->pHCI->bDevCount] = NULL;
+    pDevice->pHCData = NULL;
+    pDevice->pHCI = NULL;
+
+    return portReset && portDisable && hcdRemove;
 }
 
 HCD_Request* HCD_AddRequest(HCD_Device* pDevice, void* pEndpoint, HCD_TxDir dir, void* pBuffer, uint16_t size, uint8_t endpoint, HCD_COMPLETION_CB pFnCB, void* pCallbackData)


### PR DESCRIPTION
HCD_RemoveDevice contained three strict 'assert(result)' calls after
SetPortStatus(USB_PORT_RESET), SetPortStatus(USB_PORT_DISABLE), and
the HCD-method RemoveDevice calls (hcd.c:91, :93, :95). Two
problems:

1. In debug builds these assertions halt the system on any cleanup
   failure, even though the operations are explicitly marked 'No need
   to do that, but do it for safety'. The cleanup IS the recovery
   path; asserting in recovery means a single failed cleanup step
   halts a system that would otherwise have recovered.

2. In release builds (NDEBUG strips the asserts) the short-circuit
   'result = result && next()' chain skipped subsequent cleanup steps
   on any earlier failure, AND the 'if(result) { ...remove from
   DeviceList... }' guard skipped device-list removal entirely. A
   half-removed device stayed in HCD_Interface::DeviceList forever,
   causing subsequent enumeration to see a stale entry — strictly
   worse than partial cleanup completion.

Fix: run each cleanup step unconditionally, log any individual
failures via _LOG (debug-build only), always remove from DeviceList
regardless of step success, return aggregate AND of all three for
diagnostic purposes. ~10 lines net change, no behavioral change on
the success path.

Catalog reference: this is item #1.8 from the deep-research bug
catalog. The catalog framed the mechanism as 'class-driver pointer
dereference for unsupported classes', which is partially right: the
unsupported-class path (usb.c:362-366) is one trigger, but the actual
assertion is on SetPortStatus, not a class-driver pointer. With this
fix in place the cleanup is robust against any SetPortStatus failure
mode, including the unsupported-class path that triggered upstream
issue crazii/USBDDOS#7.

Verified by extending the QEMU regression suite from 6 to 7 tests:
the new 'ohci-audio' test attaches a usb-audio device (USB class 1,
USBC_AUDIO, no driver in USBT.ClassDrivers) and confirms USBDDOS
recognizes it as unsupported, takes the USB_RemoveDevice path, and
exits cleanly without assertion. Test 7 log captured as
regression-ohci-audio.log. The original 6 tests are unchanged.
