### PR TITLE
Gap 4: fix invalid ClearPortFeature(PORT_RESET) hub-port-reset bug

### DIFF
--- a/USBDDOS/CLASS/hub.c
+++ b/USBDDOS/CLASS/hub.c
@@ -73,14 +73,18 @@ static BOOL HUB_SetPortStatus(HCD_HUB* pHub, uint8_t port, uint16_t status)
     {
         _LOG("HUB port %d resetting\n", port);
         result = USB_HUB_SetPortFeature(HC2USB(pHub->pDevice), port, PORT_RESET) && result;
-        delay(55); //apply reset signal for 10ms+
-        result = USB_HUB_ClearPortFeature(HC2USB(pHub->pDevice), port, PORT_RESET) && result; //release reset signal
+        delay(55); //apply reset signal for 10ms+. Per USB 2.0 11.5.1.5 the hub auto-releases reset after the duration; software does not.
+        //Wait for the hub to complete the reset (PS_RESET self-clears). Bounded retry: 100 iterations * delay(5) = ~500ms cap.
+        int timeout = 100;
         do
         {
             delay(5);
             USB_HUB_PS ps; ps.val = USB_HUB_GetPortStatus(HC2USB(pHub->pDevice), port);
             current = ps.bm.status;
-        } while((current&PS_RESET)); //wait until reset is actually done. this also reload the current states
+        } while((current&PS_RESET) && --timeout > 0); //wait until reset is actually done. this also reload the current states
+        //Acknowledge the port-reset change indicator (USB 2.0 spec 11.24.2 Table 11-17: C_PORT_RESET is the valid clear-side selector).
+        //The original code used ClearPortFeature(PORT_RESET) which is NOT a valid ClearPortFeature selector per spec and STALLs on compliant hubs.
+        result = USB_HUB_ClearPortFeature(HC2USB(pHub->pDevice), port, C_PORT_RESET) && result;
 
         _LOG("HUB port %d reset %x\n", port, current);
     }
@@ -186,7 +190,7 @@ BOOL USB_HUB_InitDevice(USB_Device* pDevice)
     delay(55);
 
     {for(uint8_t i = 0; i < desc.bNbrPorts; ++i)
-        USB_HUB_ClearPortFeature(pDevice, i, PORT_RESET);}
+        USB_HUB_ClearPortFeature(pDevice, i, C_PORT_RESET);} //ack the port-reset change indicator. Spec: C_PORT_RESET is the valid clear-side selector (was PORT_RESET, which STALLs on compliant hubs).
     delay(55);
 
     //disable


### PR DESCRIPTION
The hub-class port-reset sequence in hub.c sent
ClearPortFeature(PORT_RESET=4) on the wire. Per USB 2.0 spec Table
11-17, PORT_RESET (feature selector 4) is valid only for
SetPortFeature, not ClearPortFeature; valid ClearPortFeature selectors
are PORT_ENABLE (1), PORT_SUSPEND (2), PORT_POWER (8),
PORT_INDICATOR (22), and the change-bit selectors C_PORT_CONNECTION
(16), C_PORT_ENABLE (17), C_PORT_SUSPEND (18), C_PORT_OVER_CURRENT
(19), C_PORT_RESET (20). The reset feature itself is auto-released by
the hub after the reset duration per spec 11.5.1.5; software does not
need to (and cannot) release it.

QEMU's spec-compliant usb-hub STALLed the invalid request,
USB_SyncSendRequest returned non-zero, USB_HUB_ClearPortFeature
returned FALSE, HUB_SetPortStatus returned FALSE, USB_ConfigDevice
returned FALSE at the usb.c:831 check. The trycount<=3 retry loop in
USB_BindDevice retried 4 times then USB_RemoveDevice triggered the
hcd.c:91 'result' assertion. The exact failure mode reproduced by the
ohci-hub-hid regression test added in this milestone.

Two sites fixed:
- HUB_SetPortStatus (hub.c:77): the ClearPortFeature(PORT_RESET)
  immediately after delay(55) is removed and replaced with
  ClearPortFeature(C_PORT_RESET) AFTER the wait loop, which correctly
  acknowledges the port-reset change indicator post-completion.
- USB_HUB_InitDevice (hub.c:189): the per-port
  ClearPortFeature(PORT_RESET) during hub init is changed to
  ClearPortFeature(C_PORT_RESET) for the same reason.

While in the same hot path, the wait loop at hub.c:78-83 is also
bounded by a 100-iteration timeout (~500ms cap at delay(5) per iter)
to prevent indefinite hang on a hub that fails to clear PS_RESET.
This addresses the same architectural fragility class as the
SMM-handoff loop bounded in Gap 3.

The original chat's framing of Gap 4 (hub-port-enable timing race
where the wait loop exits on !PS_RESET but PS_ENABLE hasn't latched
yet) was incorrect: QEMU's hub reads back as 0x103 (PS_CONNECTION +
PS_ENABLE + PS_POWER) at every iteration, so PS_ENABLE is in fact set
when the wait loop exits. The actual mechanism is the invalid
ClearPortFeature selector documented above.

Verified by the 6-test QEMU regression suite. Before this patch,
ohci-hub-hid FAILed at the hcd.c:91 assertion; after this patch, the
full hub-then-kbd enumeration completes (Class 3 Endpoint 81 created;
HID boot-protocol kbd successfully attached). The other 5 tests are
unchanged.

Real-hardware verification pending.
