### PR TITLE
Gap 3: bound the OHCI SMM-handoff wait loop

### DIFF
--- a/USBDDOS/HCD/ohci.c
+++ b/USBDDOS/HCD/ohci.c
@@ -84,8 +84,16 @@ BOOL OHCI_InitController(HCD_Interface* pHCI, PCI_DEVICE* pPCIDev)
         else if(HCFS == USBRESET)
         { // take ownership from SMM driver
             DPMI_MaskD(dwBase + HcCommandStatus, ~0UL, OwnershipChangeRequest);
-            while(DPMI_LoadD(dwBase + HcControl) & InterruptRouting) // wait SMM driver
+            /* Gap 3: bound the SMM handoff wait. Some BIOSes never relinquish
+             * (locked SMM, BIOS bug); the original unbounded while loop hangs
+             * USBDDOS forever in that case. Linux's quirk_usb_handoff_ohci
+             * uses a comparable 500ms cap and proceeds with a warning; we
+             * give ~1s (20 * 50ms) of headroom for slow BIOSes. */
+            int spin;
+            for(spin = 20; spin > 0 && (DPMI_LoadD(dwBase + HcControl) & InterruptRouting); --spin)
                 delay(50);
+            if(spin == 0)
+                _LOG("OHCI: SMM handoff timeout after 1s, proceeding anyway (BIOS bug?)\n");
         }
         //HCFS = (DPMI_LoadD(dwBase + HcControl) & HostControllerFunctionalState) >> HostControllerFunctionalState_SHIFT;
         //_LOG("HCFS: %d\n", HCFS);


### PR DESCRIPTION
OHCI_InitController contained an unbounded while loop waiting for SMM
to relinquish ownership (the InterruptRouting bit in HcControl clears
once SMM is done). Some BIOSes never relinquish: locked SMM, BIOS bug,
or controller hardware lockup. In those cases USBDDOS hangs forever
at driver load.

Implementation: 20-iteration spin counter at 50ms intervals = 1s cap.
Matches Linux's quirk_usb_handoff_ohci pattern in pci-quirks.c (500ms
cap via wait_time = 500, decremented by 10 per msleep(10) iteration).
We give ~1s for slow BIOSes since DOS has no hard real-time requirement.

If the timeout fires we log a 'BIOS bug?' warning and continue init.
If the controller is genuinely wedged the subsequent HC reset will
fail visibly rather than hang silently.

Effect on common path: zero (BIOS handoff completes well within 50ms).
Real-hardware verification pending on silicon with active SMM USB
handoff (Mac Mini 2011, ICH7 with USB Legacy in BIOS).
