### PR TITLE
Gap 5: disable OHCI Legacy Support emulation after BIOS handoff

### DIFF
--- a/USBDDOS/HCD/ohci.c
+++ b/USBDDOS/HCD/ohci.c
@@ -123,6 +123,19 @@ BOOL OHCI_InitController(HCD_Interface* pHCI, PCI_DEVICE* pPCIDev)
         //HCFS = (DPMI_LoadD(dwBase + HcControl) & HostControllerFunctionalState) >> HostControllerFunctionalState_SHIFT;
         //_LOG("HCFS: %d\n", HCFS);
     }
+
+    /* Gap 5: disable OHCI Legacy Support emulation now that we've taken
+     * ownership. On chips that implement Legacy Support (NEC µPD720101,
+     * SiS 7001, etc.), BIOS may have left the keyboard/mouse PS/2-style
+     * emulation active. With our driver running, that emulation can
+     * spuriously generate interrupts or compete for the same MMIO state.
+     * Writing 0 to HceControl clears EmulationEnable (and all other
+     * Legacy Support state). Per OHCI 1.0a Appendix B, HceControl is
+     * at MMIO 0x100; on chips without Legacy Support the offset is
+     * reserved/RAZ and the write is silently ignored, so this is
+     * universally safe. */
+    DPMI_StoreD(dwBase + HceControl, 0);
+
     /* Gap 6: read-modify-write of HcFmInterval to preserve the BIOS-tuned
      * value across the soft reset. On ALi M5237 (and other chips matching
      * OHCI_HasFmIntervalLockup), reading HcFmInterval locks the entire

--- a/USBDDOS/HCD/ohci.h
+++ b/USBDDOS/HCD/ohci.h
@@ -83,6 +83,13 @@
 #define PortOverCurrentIndicatorChange BIT19
 #define PortResetStatusChange   BIT20
 
+//OHCI 1.0a Appendix B Legacy Support Interface Specification.
+//Implemented on chips with Legacy keyboard/mouse emulation (NEC µPD720101,
+//SiS 7001, etc.). Reserved/RAZ on non-Legacy-Support implementations -
+//writes are silently ignored.
+#define HceControl              0x100L
+#define EmulationEnable         BIT0
+
 #define PIDFROMTD               0 //for control ED PID
 #define PIDSETUP                0
 #define PIDOUT                  1


### PR DESCRIPTION
OHCI 1.0a Appendix B defines a 'Legacy Support Interface' that
implements PS/2-style emulation for USB keyboard/mouse, used to
service legacy software via system management interrupts before an
HCD takes over. On NEC µPD720101 and SiS 7001 silicon (HcRevision=0x110
per OHCI 1.0a Appendix B) this emulation can stay active after BIOS
handoff and interfere with HCD operation.

This patch writes 0 to HceControl (offset 0x100) immediately after
the BIOS/SMM ownership-handoff block in OHCI_InitController. The
write clears EmulationEnable plus all other Legacy Support state in a
single store.

Universally safe per spec: chips that don't implement Legacy Support
have offset 0x100 as reserved/RAZ and silently ignore the write. On
the dual-OHCI µPD720101, OHCI #2's offset 0x100 is also in a reserved
region. Deliberately not gated on HcRevision bit 8 because per the
µPD720101 user manual section 4.2.3, that bit is board-dependent via
the LEGC pin and unreliable as a Legacy-Support detection signal.

Side effect on previously-emulating silicon: BIOS keyboard handoff
stops working after USBDDOS load. This is desired behavior for our
target use case (USBDDOS owns the HID stack).

Real-hardware verification pending on NEC µPD720101 or SiS 7001.
