### PR TITLE
Gap h dpmi page boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,137 @@
+# Changelog
+
+All notable changes to Netrunner01/USBDDOS are documented here. This
+fork derives from [crazii/USBDDOS](https://github.com/crazii/USBDDOS)
+commit `54345d0` (Feb 6, 2024). Upstream's own versioning is not
+modified by this fork; the version strings below identify fork-side
+iteration only.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/)
+for the fork-side suffix.
+
+## [1.0.0-alpha.1] — 2026-05-13
+
+**Alpha designation rationale**: this release is `-alpha` because
+real-hardware verification on the silicon each patch targets is
+pending — NOT because the code is unstable or broken. All patches
+build clean with `-Werror` on both Open Watcom v2 and DJGPP gcc
+12.2.0, and pass a 7-test QEMU regression suite. Patch designs are
+derived from authoritative sources (USB-IF specs, Linux
+`pci-quirks.c` and `ohci-hcd.c`, Apple Darwin `IOUSBFamily`, FYSOS
+Book 8, and chip vendor datasheets). The verification gap is
+specifically the proof that each chip-quirk fix behaves correctly
+on the real silicon it targets — QEMU emulates spec-compliant USB
+devices, and the patched paths exist precisely because real silicon
+deviates from spec.
+
+Promotion criteria: this release moves to `-beta` when at least one
+independent real-hardware test report exists per patched gap.
+General-availability `v1.0.0` (drop the `-alpha`/`-beta` suffix)
+when each gap has at least one PASS report on its target silicon.
+
+### Added (chip-quirk fixes)
+* **Gap 1** — OHCI `UnrecoverableError` recovery per OHCI 1.0a
+  §5.3.1.1. The UE handler in `OHCI_ISR` was empty upstream
+  (`//return TRUE;`); now performs full HC reset and operational-
+  register restore. Files: `USBDDOS/HCD/ohci.c`.
+* **Gap 2** — INITRESET-equivalent verify-and-retry for
+  `HcFmInterval` / `HcPeriodicStart` latching on OPTi 82C861
+  (FireLink) and certain SiS OHCI silicon. Mirrors Linux's
+  `OHCI_QUIRK_INITRESET`. Files: `USBDDOS/HCD/ohci.c`.
+* **Gap 3** — Bounded SMM-handoff wait loop (~1 s cap, 20 × 50 ms
+  poll). Replaces the upstream unbounded `while` that hangs on
+  BIOSes which never release SMM ownership. Mirrors Linux's
+  `quirk_usb_handoff_ohci` pattern. Files: `USBDDOS/HCD/ohci.c`.
+* **Gap 4** — Fixed invalid `ClearPortFeature(PORT_RESET)` hub-port-
+  reset spec violation in `USBDDOS/CLASS/hub.c`. Per USB 2.0
+  Table 11-17, `PORT_RESET` (feature 4) is a `SetPortFeature` selector
+  only; the post-reset change indicator is cleared via
+  `ClearPortFeature(C_PORT_RESET)` (feature 20) instead. Fix applied
+  at both call sites (lines 77 and 189). Wait loop also bounded with
+  a 100-iteration timeout (~500 ms cap). Files: `USBDDOS/CLASS/hub.c`.
+* **Gap 5** — Disable OHCI Legacy Support emulation after BIOS
+  handoff (one-shot `HceControl = 0` write at offset 0x100). Prevents
+  PS/2-style emulation from interfering with HCD operation on NEC
+  µPD720101, SiS 7001, and similar Legacy-Support-capable silicon.
+  Universally safe per spec: chips without Legacy Support treat the
+  offset as reserved/RAZ. Files: `USBDDOS/HCD/ohci.c`,
+  `USBDDOS/HCD/ohci.h`.
+* **Gap 6** — Skip `HcFmInterval` access on ALi/ULi M5237 OHCI
+  silicon (PCI ID `10B9:5237`) — read/restore causes hard system
+  lockup. Mirrors Linux's `no_fminterval` flag in
+  `quirk_usb_handoff_ohci`. Default `OHCI_FI_DEFAULT = 0x2EDF`
+  substituted. Files: `USBDDOS/HCD/ohci.c`.
+* **Gap 8** — Wait `POTPGT × 2 ms` after `SetPortPower` per OHCI
+  1.0a §7.4.1. POTPGT is read from `HcRhDescriptorA` bits 24-31;
+  the previously missing wait caused intermittent hot-plug
+  enumeration failures on NEC µPD720101 (datasheet POTPGT default
+  0x0F = 30 ms). Files: `USBDDOS/HCD/ohci.c`.
+
+### Added (defensive fixes)
+* `HCD_RemoveDevice` teardown made defensive. Strict `assert(result)`
+  calls in the three-step cleanup path replaced with logged best-
+  effort cleanup. Each step now runs unconditionally; device-list
+  removal happens regardless of individual step success. Fixes a
+  latent device-list-leak in release builds (NDEBUG strips the
+  asserts but the short-circuit `result = result && ...` chain
+  still skipped subsequent cleanup steps). Resolves the symptoms
+  reported in crazii/USBDDOS#7. Files: `USBDDOS/HCD/hcd.c`.
+
+### Added (developer-facing)
+* COM1 logging path in `_LOG` enabled (was gated off with `#if 0`
+  upstream). Required for headless emulator regression and
+  serial-console real-hardware debugging. Behavior unchanged on
+  release builds (NDEBUG strips `_LOG` entirely). Resolves
+  crazii/USBDDOS#19. Files: `USBDDOS/dbgutil.c`.
+* Case-correct `#include` paths for cross-build on Linux. Same fix
+  shape as `stanwebber/USBDDOS` (8 commits dated April 25, 2025);
+  independently derived, credit to stanwebber for the prior
+  independent work and for filing crazii/USBDDOS#17. Files:
+  `USBDDOS/HCD/hcd.h`, `RetroWav/Board/opl3.c`, `RetroWav/Board/opl3.h`,
+  `RetroWav/Platform/dos_cdc.h`, `RetroWav/Protocol/serial.c`,
+  `RetroWav/retrowav.c`, `USBDDOS/dbgutil.c`, `main.c`.
+* `README.md` fork-front-page section: purpose, scope, "who this
+  fork is for" symptom keys, common-symptom verbatim error strings,
+  affected-hardware aliases, related-software terms. Designed for
+  search-engine discoverability by users hunting their own log
+  messages.
+
+### Tooling
+* 7-test QEMU regression harness (`run-test.sh`, distributed
+  separately): `ohci-init`, `ohci-kbd`, `ohci-msc`, `uhci-init`,
+  `ehci-init`, `ohci-hub-hid` (Gap 4 reproducer), `ohci-audio`
+  (unsupported-class HCD-teardown exerciser).
+
+### Known limitations (carried into next iteration)
+* No real-hardware test runs yet. See Status section in `README.md`.
+* **Gap 7** — NEC `kErrataNECIncompleteWrite` write-1-to-clear retries
+  on `HcRhPortStatus` is sketched (from Apple Darwin
+  `AppleUSBOHCI_RootHub.cpp`) but not yet patched. Affects µPD720101
+  under specific load patterns.
+* **EHCI USBLEGSUP/USBLEGCTLSTS BIOS handoff** is not implemented.
+  Gap 3 covers the OHCI side; the EHCI-side analogue (which Linux's
+  `quirk_usb_disable_ehci` covers, including the
+  `EHCI_USBLEGCTLSTS_SOOE` SMI-on-Ownership-Change-Enable bit) is
+  the most likely root cause of unresolved upstream hangs on Intel
+  Cougar Point / Panther Point platforms (crazii/USBDDOS#10, #20,
+  and the Gigabyte P67-DS3-B3 thread on VOGONS).
+* **xHCI** support is upstream-planned and out of scope for this
+  fork.
+
+### Build details
+* **Open Watcom v2 debug build**: `usbddos.exe`, 94,380 bytes,
+  bit-stable across rebuilds at this commit.
+* **DJGPP gcc 12.2.0 release build**: `usbddosp.exe`, 207,872 bytes.
+  Byte-content varies across rebuilds — the build embeds
+  `git rev-parse --short HEAD` into the binary via `-DUSBDDOS_BUILD`,
+  so the 7-character commit-hash string differs between source-
+  identical rebuilds at different commits. The non-hash code bytes
+  are identical.
+
+### Reference upstream commit
+* `54345d0` — `BC/WC: bugfix on loading ivt` (Feb 6, 2024). This is
+  the commit on `master` that this fork's series rebases onto.
+  Verified accessible via `git ls-remote https://github.com/crazii/USBDDOS.git`.
+
+[1.0.0-alpha.1]: https://github.com/Netrunner01/USBDDOS/releases/tag/v1.0.0-alpha.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,82 @@
 # Changelog
 
 All notable changes to Netrunner01/USBDDOS are documented here. This
-fork derives from [crazii/USBDDOS](https://github.com/crazii/USBDDOS)
-commit `54345d0` (Feb 6, 2024). Upstream's own versioning is not
-modified by this fork; the version strings below identify fork-side
-iteration only.
+fork derives from [crazii/USBDDOS](https://github.com/crazii/USBDDOS);
+the initial alpha was based on upstream `54345d0` (Feb 6, 2024), and
+subsequent releases track upstream as the fork's patches are merged
+in. Upstream's own versioning is not modified by this fork; the
+version strings below identify fork-side iteration only.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/)
 for the fork-side suffix.
+
+## [1.0.0-alpha.2] — 2026-05-15
+
+**This is a housekeeping release.** No new code, no functional
+changes, no bug fixes. The alpha.2 binaries are byte-identical (Watcom)
+or near-identical (DJGPP differs by 7 bytes of embedded build-hash) to
+the alpha.1 binaries. If alpha.1 is already running on your system, do
+not update — there is no reason to.
+
+**Why cut a release at all, then?** Between May 13 and May 15, 2026,
+upstream `crazii/USBDDOS` merged every patch from this fork's
+`v1.0.0-alpha.1` patch series (PRs #22–#30). The patches now live at
+upstream `master` (`b1308fb`) and are no longer carried as fork-side
+cherry-picks. This release exists solely to refresh the binaries' build
+provenance so they map to a public upstream commit rather than to a
+fork-internal tag — useful for anyone wanting to verify "these binaries
+correspond to crazii/USBDDOS at commit X" without trusting fork-side
+state.
+
+**Alpha designation (carried forward unchanged from alpha.1)**:
+real-hardware verification on the silicon the patches target is still
+pending. The alpha label remains accurate because the field-validation
+criterion has not changed and is not affected by where the source
+lives. Promotion to beta or v1.0.0 still requires at least one
+independent real-hardware test report per patched gap.
+
+### Changed
+* **Source provenance**: binaries are now built from upstream master
+  at commit `b1308fb`, not from fork-side cherry-picks. Anyone can
+  `git clone https://github.com/crazii/USBDDOS.git && git checkout b1308fb`
+  and build a byte-identical Watcom binary.
+* **Build hash embedded in DJGPP binary**: `b1308fb, DJGPP` (was
+  `afb2b84, DJGPP` in alpha.1). This is the only differing region
+  between alpha.1 and alpha.2 DJGPP binaries.
+
+### Upstream merge order (for the record)
+1. PR #17 (stanwebber: case-correct `#include` paths) — merged
+   earlier; fork's own case-fix patch deferred in favor of this one.
+2. PR #22 (debug: COM1 logging)
+3. PR #23 (HCD defensive teardown)
+4. PR #24 (Gap 4: hub `ClearPortFeature(PORT_RESET)` spec violation)
+5. PR #25 (Gap 8: POTPGT wait)
+6. PR #26 (Gap 2: INITRESET-equivalent retry)
+7. PR #27 (Gap 3: SMM-handoff bound)
+8. PR #28 (Gap 1: OHCI UnrecoverableError recovery)
+9. PR #29 (Gap 6: ALi M5237 HcFmInterval lockup avoidance)
+10. PR #30 (Gap 5: OHCI Legacy Support emulation disable)
+
+### Unchanged
+* Functional code: all patches landed unmodified. The Open Watcom v2
+  debug build is byte-identical to alpha.1's (MD5
+  `39962c2092961ba679467ba46ab24c43`, 94,380 bytes), confirming that
+  Crazii merged each patch as-submitted and that stanwebber's
+  case-fix has no effect on Windows-built (case-insensitive)
+  binaries.
+
+### Build details
+* **Open Watcom v2 debug build**: `usbddos.exe`, 94,380 bytes,
+  MD5 `39962c2092961ba679467ba46ab24c43`, bit-stable across rebuilds.
+* **DJGPP gcc 12.2.0 release build**: `usbddosp.exe`, 207,872 bytes,
+  MD5 `2b1b0221f338c59041e7e6ec18827ef9`. Byte-content of all non-hash
+  regions identical to alpha.1.
+
+### Reference upstream commit
+* `b1308fb` — `Merge pull request #30 from netrunner01/fix/ohci-legacy-support-disable`
+  (May 15, 2026). All of the fork's alpha.1 patch series is reachable
+  from this commit.
 
 ## [1.0.0-alpha.1] — 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,295 @@
+# Netrunner01/USBDDOS — fork
+
+## Status
+
+**Current version: `v1.0.0-alpha.1`.** The "alpha" label here means
+**real-hardware verification is pending — NOT that the code is unstable
+or broken.** Specifically:
+
+* All 11 commits build clean with `-Werror` on Open Watcom v2 and
+  DJGPP gcc 12.2.0.
+* The 7-test QEMU regression suite passes 7/7
+  (`ohci-init`, `ohci-kbd`, `ohci-msc`, `uhci-init`, `ehci-init`,
+  `ohci-hub-hid`, `ohci-audio`).
+* Every patch is derived from authoritative documentation: the
+  USB 2.0 spec (for the Gap 4 hub-class fix), Linux `pci-quirks.c`
+  and `ohci-hcd.c` (for Gaps 2, 3, 6), Apple Darwin `IOUSBFamily`
+  (for the pending Gap 7), the NEC µPD720101 / ALi M5237 / SiS 630 /
+  OPTi 82C861 chip datasheets, and Benjamin Lunt's FYSOS Book 8
+  (for Gap 8).
+* What's missing: a regression pass against the actual silicon each
+  chip-quirk fix targets. QEMU implements *spec-compliant* USB
+  devices; the patched paths exist precisely because real silicon
+  deviates from spec. So while the code "works" in the emulator,
+  the proof that each fix behaves correctly against the chip it
+  targets is missing.
+
+**The fork moves from alpha to beta** when at least one independent
+real-hardware test report exists per patched gap. If you have NEC
+µPD720101, ALi M5237 / M1543C, SiS 7001, OPTi 82C861, or a
+Mac-Mini-2011-class Intel PCH platform and can run a smoke test,
+[file an issue](https://github.com/Netrunner01/USBDDOS/issues) with
+the results either way — that's the single most useful contribution
+this project needs right now.
+
+## Why this fork exists
+
+Upstream `crazii/USBDDOS` has not received a maintainer commit since
+February 2024, and the issue tracker has accumulated bug reports with
+no resolutions. Several of those bugs have specific identifiable root
+causes — some with one-line fixes that have been sitting in users'
+forks for over a year. This fork is a place those fixes live in one
+public location so people who actually need a working USB driver
+stack on legacy DOS hardware can use one without compiling it
+themselves.
+
+It is a small, deliberately-scoped fork. It is not a competing project
+or a hostile takeover bid. If upstream resumes, the patches here are
+designed to land as clean per-issue commits on `crazii/USBDDOS` with
+no rebasing required.
+
+## Who this fork is for
+
+You probably want this if you've hit one of these and there isn't a
+working solution upstream:
+
+* **System hangs on USBDDOS load** on a 386/486/Pentium-era board with
+  an **ALi M5237** OHCI controller, or an OEM **ALi M1543C
+  southbridge**. (Fixed: Gap 6.)
+* **System hangs on USBDDOS load** during BIOS USB-Legacy SMM handoff
+  on motherboards with stuck SMI ownership — common on **Mac Mini
+  2011**, **Sandy Bridge ThinkPads**, **Intel Cougar Point chipsets**,
+  some VIA southbridges. (Partially addressed: Gap 3; full EHCI
+  handoff still pending.)
+* **USB hub does not work** — devices behind a hub fail to enumerate
+  even though USBDDOS sees the hub itself. (Fixed: Gap 4.)
+* **Driver works for keyboard but crashes when an unsupported USB
+  device is plugged in** (audio, printer, vendor-specific). Cleanup
+  asserts at `hcd.c(91)`. (Fixed: HCD teardown commit.)
+* **OHCI driver dies silently on certain controllers** after an
+  Unrecoverable Error interrupt — the recovery handler was empty.
+  (Fixed: Gap 1.)
+* **PS/2 keyboard ghosting / spurious interrupts** while USBDDOS is
+  loaded on a NEC µPD720101 or SiS 7001 OHCI controller because BIOS
+  left Legacy Support active. (Fixed: Gap 5.)
+* **Random init failures on OPTi 82C861 (FireLink)** or older SiS
+  OHCI silicon where `HcFmInterval` doesn't latch on first write.
+  (Fixed: Gap 2.)
+* **Headless emulator testing or serial-console real-hardware
+  debugging** needs `_LOG` output on COM1, which upstream gates off.
+  (Fixed: Debug commit.)
+* **Cross-building from Linux** with the DJGPP or Open Watcom v2
+  toolchain hits "file not found" on `#include` paths because of
+  mixed-case originals. (Fixed: Build commit.)
+
+If your problem isn't on this list, this fork is unlikely to help —
+it does NOT add new features beyond what upstream offers (USB
+1.1/2.0 host controllers, HID keyboard/mouse, mass storage, CDC,
+hub class). Two known bugs in upstream are deliberately NOT yet
+patched here: NEC `kErrataNECIncompleteWrite` write-1-to-clear
+retries on `HcRhPortStatus` (Gap 7 in our planning notes) and full
+EHCI USBLEGSUP/USBLEGCTLSTS BIOS handoff for the Intel ICH4+
+systems. Both are tracked.
+
+## Background
+
+A research fork of [crazii/USBDDOS](https://github.com/crazii/USBDDOS)
+maintained at upstream commit `54345d0` (Feb 2024). The patch series
+in this fork was developed against the **Rescue-D2** project, a
+1.44 MB FreeDOS rescue floppy targeting 386–486 / early-Pentium
+hardware (NEC, ALi, SiS, and OPTi OHCI silicon). The Rescue-D2 use
+case puts more breadth-pressure on USBDDOS's chip-quirk handling
+than the typical RetroWave-OPL3 / retro-gaming use cases upstream
+was tuned for, which surfaced the gaps below.
+
+## What this fork adds
+
+Ten discrete commits on top of upstream `54345d0`. Each is a single
+logical change with a detailed commit message and inline source
+comments explaining the mechanism, hardware exposure, and spec
+references; `git log 54345d0..master` gives the full series.
+
+| Topic | Brief | Related upstream issue |
+|---|---|---|
+| Build | Case-correct `#include` paths for cross-build on Linux | [#17](https://github.com/crazii/USBDDOS/issues/17) |
+| Debug | Enable COM1 logging in `_LOG` path for headless emulator testing | [#19](https://github.com/crazii/USBDDOS/issues/19) |
+| Gap 1 | OHCI UnrecoverableError recovery per OHCI 1.0a §5.3.1.1 | — |
+| Gap 6 | Skip HcFmInterval access on ALi M5237 to prevent system lockup | — |
+| Gap 5 | Disable OHCI Legacy Support emulation after BIOS handoff | — |
+| Gap 3 | Bound the SMM-handoff wait loop (~1s cap) | — |
+| Gap 2 | INITRESET-equivalent verify-and-retry for HcFmInterval/HcPeriodicStart latching | — |
+| Gap 8 | Wait POTPGT × 2ms after SetPortPower | — |
+| Gap 4 | Fix invalid `ClearPortFeature(PORT_RESET)` hub-port-reset spec violation | — |
+| HCD | Relax `HCD_RemoveDevice` teardown asserts to logged best-effort cleanup | [#7](https://github.com/crazii/USBDDOS/issues/7) |
+
+The Build commit duplicates work `stanwebber` already did in
+[stanwebber/USBDDOS](https://github.com/stanwebber/USBDDOS) (8 commits
+dated April 25, 2025, byte-identical fix shape). Both were derived
+independently from the same observation; credit for the prior
+independent work goes to stanwebber.
+
+## What this fork does NOT do
+
+* **Not a drop-in replacement for upstream.** It does not address
+  every reported issue in the upstream tracker, and behavior outside
+  the changed code paths is unaffected.
+* **Real-hardware verification is pending for all six OHCI gap
+  fixes.** Each gap was identified against authoritative documentation
+  (OHCI 1.0a spec, Linux `pci-quirks.c`, NEC µPD720101 user manual,
+  SiS 630 datasheet, FYSOS Book 8) or silicon-vendor errata captured
+  in Apple Darwin's `IOUSBFamily`. The quirk paths the fixes target
+  are NOT exercised by QEMU's spec-compliant `pci-ohci` emulation. So
+  while the patches build cleanly with `-Werror` on both toolchains
+  and don't regress the QEMU-side 5/5 baseline regression suite, none
+  of them is yet confirmed to behave correctly on the real silicon
+  the fix is meant for.
+* **One known OHCI gap remains unpatched:**
+  * Gap 7 — NEC `kErrataNECIncompleteWrite` write-1-to-clear retries
+    on `HcRhPortStatus`. Fix sketched from Apple Darwin
+    `IOUSBFamily/AppleUSBOHCI_RootHub.cpp`, not yet written. Affects
+    µPD720101 silicon under specific load patterns.
+* **EHCI USBLEGSUP/USBLEGCTLSTS BIOS handoff is not implemented.**
+  Gap 3 handles the OHCI side, but the EHCI-side analogue (which
+  Linux's `quirk_usb_disable_ehci` covers, including the
+  `EHCI_USBLEGCTLSTS_SOOE` SMI-on-Ownership-Change-Enable bit) is
+  the most likely root cause of unresolved upstream hangs on Intel
+  Cougar Point / Panther Point platforms — see crazii/USBDDOS#10 and
+  the Gigabyte P67-DS3-B3 thread on VOGONS.
+* **xHCI support is not implemented.** Upstream lists it as a planned
+  feature; this fork does not extend the planned-feature scope.
+* **No upstream PR campaign.** Upstream `crazii/USBDDOS` is treated
+  as functionally dormant. Engagement, where it happens, is per-issue:
+  deferring case-fix attribution to `stanwebber` on
+  [#17](https://github.com/crazii/USBDDOS/issues/17), and offering the
+  COM1 log change as an answer on
+  [#19](https://github.com/crazii/USBDDOS/issues/19).
+
+## Building
+
+Build instructions are unchanged from upstream — see the [How to
+Build](#how-to-build) section below. The fork builds clean with
+`-Werror` on:
+
+* Open Watcom v2 (May 2026 snapshot or later) — produces the
+  deployment binary `usbddos.exe`.
+* DJGPP cross gcc 12.2.0 — produces `usbddosp.exe`.
+
+The Watcom build is bit-stable across rebuilds at the same commit.
+The DJGPP build embeds a build-ID string (the git short-hash), so the
+binary's bytes differ when the same source is rebuilt from a different
+commit even though the code is identical.
+
+## Reporting issues
+
+This fork's tracker is on this repository
+([issues page](https://github.com/Netrunner01/USBDDOS/issues)). Issues
+that are about upstream USBDDOS rather than this fork's specific
+changes belong on [upstream's tracker](https://github.com/crazii/USBDDOS/issues).
+
+## Common symptoms this fork addresses
+
+If you arrived here from a web search, the strings below are the
+actual error output or symptom descriptions from the bugs this fork
+patches. They are listed verbatim so search engines return this
+README as a hit for users hunting the symptoms in their own logs.
+
+* `assertion failed: result` at `../USBDDOS/HCD/hcd.c(91)` — fixed by
+  the HCD-teardown commit, in combination with Gap 4 for the hub
+  enumeration path.
+* `assertion failed: result` at `../USBDDOS/HCD/hcd.c(93)` or
+  `(95)` — same root cause, same fix.
+* `HUB port N resetting` followed by `HUB port N reset 103` repeated
+  ~4 times, then `USB Removing HCD device` and assertion — Gap 4
+  (invalid `ClearPortFeature(PORT_RESET)`).
+* USBDDOS hangs at load on an ALi M1543C / ULi southbridge or a
+  standalone ALi/ULi M5237 OHCI controller with no log output — Gap 6
+  (`HcFmInterval` access lockup).
+* USBDDOS hangs at load on a system with BIOS USB Legacy Support
+  enabled that won't release SMM ownership — Gap 3 (unbounded SMM
+  handoff loop). This is partial coverage; full coverage of Intel
+  PCH-class platforms also requires the EHCI USBLEGSUP handoff
+  which is not yet implemented.
+* PS/2-emulated keyboard ghosts characters or fires spurious
+  interrupts when USBDDOS is loaded on a NEC µPD720101 or SiS 7001
+  OHCI controller — Gap 5 (Legacy Support emulation not disabled
+  after BIOS handoff).
+* USBDDOS init silently fails to bring up the OHCI controller on
+  OPTi 82C861 (FireLink) or older SiS OHCI silicon, even though the
+  PCI enumeration succeeded — Gap 2 (`HcFmInterval` /
+  `HcPeriodicStart` don't latch on first write).
+* OHCI controller stops working after a `HcInterruptStatus.UE`
+  (UnrecoverableError) interrupt is raised, with no recovery —
+  Gap 1 (UE handler was empty upstream).
+* Hot-plugged USB device on an OHCI root-hub port intermittently
+  fails to enumerate on real hardware (works on second try) —
+  Gap 8 (`POTPGT` wait after `SetPortPower` was missing).
+* Plugging in any USB device whose class is unsupported by USBDDOS
+  (audio class 1, printer class 7, vendor-specific 0xFF, etc.)
+  triggers an assertion and hangs the system instead of skipping the
+  device — fixed by the HCD-teardown commit (relevant to upstream
+  [#7](https://github.com/crazii/USBDDOS/issues/7)).
+* Building USBDDOS from source on Linux (DJGPP cross or Open Watcom
+  v2) fails with `cannot find file` errors on `#include` directives —
+  the Build commit (case-sensitivity fix, same shape as
+  [stanwebber's #17](https://github.com/crazii/USBDDOS/issues/17)).
+
+### Affected hardware (search aliases)
+
+NEC µPD720101 · NEC µPD720100A · NEC µPD9210 · NEC USB 2.0 PCI card ·
+ALi M5237 · ALi M1543C · ALi M1535+ · ULi M1573 ·
+SiS 7001 · SiS 7002 · SiS 630 · SiS 5595 ·
+OPTi 82C861 · OPTi FireLink ·
+Intel ICH4 · ICH5 · ICH6 · ICH7 · ICH8 · ICH9 · ICH10 ·
+Cougar Point · Panther Point · NM10 ·
+VIA VT82C686A · VT82C686B · VT8231 · VT8233 · VT8235 · VT8237 ·
+AMD-756 · AMD-768 · AMD SB700 · SB710 · SB800 · KT133A ·
+Mac Mini 2011 · Sandy Bridge ThinkPad · Compaq Evo N600c ·
+Toshiba Portege M200 · Toshiba Satellite 2410 · Lenovo ThinkPad T540p ·
+Asus Eee PC · Intel Atom Cedarview · Gigabyte P67-DS3-B3 ·
+ASRock ION 330.
+
+### Related software / project terms
+
+USBDDOS · USBDDOSP · USB driver DOS · DOS USB stack ·
+FreeDOS · MS-DOS · DR-DOS · PC DOS ·
+CWSDPMI · HDPMI32 · HDPMI32i · HX DPMI · JEMM386 · JEMMEX · QEMM386 ·
+CTMOUSE · cutemouse · MS-DOS mouse ·
+SBEMU · Sound Blaster emulator · RetroWav · RetroWave OPL3 · weeCee ·
+USBDOS (Bret Johnson's separate driver — not the same project) ·
+USBUHCIL · USBOHCIL · USBEHCIL · USBJSTIK · USBDRIVE ·
+Rescue-D2 · UBCD · UnetbootIn · DESKTOP2 · FreeDOS rescue floppy ·
+86Box · QEMU · Bochs · DOSBox · DOSBox-X · PCem · VirtualBox legacy ·
+OHCI · UHCI · EHCI · xHCI · Open Host Controller Interface ·
+Universal Host Controller Interface · Enhanced Host Controller Interface ·
+USB 1.1 DOS driver · USB 2.0 DOS driver · USB DOS driver fix ·
+DOS USB host controller · DOS USB hub support · DOS USB enumeration ·
+DOS USB keyboard · DOS USB mouse · DOS USB mass storage ·
+DOS USB rescue floppy · retro PC USB · vintage PC USB · retrocomputing ·
+Pentium-era PC · 486-era PC · 386-era PC · Socket 7 USB · Slot 1 USB.
+
+## License
+
+GPL-2.0, inherited unchanged from upstream `crazii/USBDDOS`. See
+[COPYING](./COPYING) for the full text. All credits in the upstream
+README apply unchanged.
+
+## Additional credits for fork work
+
+* Linux USB host-controller code (`drivers/usb/host/ohci-hcd.c`,
+  `pci-quirks.c`) — reference for Gaps 2, 3, and 6.
+* Apple Darwin `IOUSBFamily` `AppleUSBOHCI` — reference for the
+  NEC errata behind the (pending) Gap 7.
+* Benjamin Lunt (fysnet), *FYSOS Book 8* — POTPGT semantics behind
+  Gap 8.
+* NEC µPD720101 User's Manual (S16336EJ4V0UM) and Datasheet (S16265E),
+  ALi M1543C datasheet, SiS 630 datasheet — primary OHCI silicon
+  references for Gaps 5, 6, and 8.
+
+---
+
+*The remainder of this README is the upstream content unchanged from
+[crazii/USBDDOS@54345d0](https://github.com/crazii/USBDDOS/tree/54345d0).*
+
 # USBDDOS
 USB driver stack for DOS
 

--- a/README.md
+++ b/README.md
@@ -2,51 +2,70 @@
 
 ## Status
 
-**Current version: `v1.0.0-alpha.1`.** The "alpha" label here means
-**real-hardware verification is pending — NOT that the code is unstable
-or broken.** Specifically:
+**Current version: `v1.0.0-alpha.2` (May 15, 2026)** — housekeeping
+release; no new code or features.
 
-* All 11 commits build clean with `-Werror` on Open Watcom v2 and
+Every patch from `v1.0.0-alpha.1` was merged into upstream
+`crazii/USBDDOS` between May 13 and May 15, 2026. Upstream master is
+at `b1308fb`. The alpha.2 binaries on the release page are built
+directly from upstream master and are byte-identical (Watcom) or
+near-identical (DJGPP, differing only in an embedded build-hash) to
+the alpha.1 binaries. If alpha.1 is already running on your system,
+there is no reason to update; alpha.2 exists for build-provenance
+clarity, not as a functional change.
+
+**The "alpha" label still means real-hardware verification is
+pending — NOT that the code is unstable or broken.** Specifically:
+
+* All upstream code builds clean with `-Werror` on Open Watcom v2 and
   DJGPP gcc 12.2.0.
 * The 7-test QEMU regression suite passes 7/7
   (`ohci-init`, `ohci-kbd`, `ohci-msc`, `uhci-init`, `ehci-init`,
   `ohci-hub-hid`, `ohci-audio`).
-* Every patch is derived from authoritative documentation: the
+* Every patch was derived from authoritative documentation: the
   USB 2.0 spec (for the Gap 4 hub-class fix), Linux `pci-quirks.c`
   and `ohci-hcd.c` (for Gaps 2, 3, 6), Apple Darwin `IOUSBFamily`
   (for the pending Gap 7), the NEC µPD720101 / ALi M5237 / SiS 630 /
   OPTi 82C861 chip datasheets, and Benjamin Lunt's FYSOS Book 8
   (for Gap 8).
-* What's missing: a regression pass against the actual silicon each
-  chip-quirk fix targets. QEMU implements *spec-compliant* USB
+* What's still missing: a regression pass against the actual silicon
+  each chip-quirk fix targets. QEMU implements *spec-compliant* USB
   devices; the patched paths exist precisely because real silicon
-  deviates from spec. So while the code "works" in the emulator,
-  the proof that each fix behaves correctly against the chip it
-  targets is missing.
+  deviates from spec.
 
-**The fork moves from alpha to beta** when at least one independent
-real-hardware test report exists per patched gap. If you have NEC
-µPD720101, ALi M5237 / M1543C, SiS 7001, OPTi 82C861, or a
-Mac-Mini-2011-class Intel PCH platform and can run a smoke test,
-[file an issue](https://github.com/Netrunner01/USBDDOS/issues) with
-the results either way — that's the single most useful contribution
-this project needs right now.
+**Promotion to beta or v1.0.0** requires at least one independent
+real-hardware test report per patched gap. If you have NEC µPD720101,
+ALi M5237 / M1543C, SiS 7001, OPTi 82C861, or a Mac-Mini-2011-class
+Intel PCH platform and can run a smoke test, [file an
+issue](https://github.com/Netrunner01/USBDDOS/issues) with the results
+either way — that's the single most useful contribution this project
+needs right now.
 
 ## Why this fork exists
 
-Upstream `crazii/USBDDOS` has not received a maintainer commit since
-February 2024, and the issue tracker has accumulated bug reports with
-no resolutions. Several of those bugs have specific identifiable root
-causes — some with one-line fixes that have been sitting in users'
-forks for over a year. This fork is a place those fixes live in one
-public location so people who actually need a working USB driver
-stack on legacy DOS hardware can use one without compiling it
-themselves.
+When this fork was started in May 2026, upstream `crazii/USBDDOS` had
+not received a maintainer commit since February 2024 and the issue
+tracker had accumulated bug reports with no resolutions. The fork's
+purpose was to provide a public home for a focused set of fixes that
+users had identified but never seen merged.
 
-It is a small, deliberately-scoped fork. It is not a competing project
-or a hostile takeover bid. If upstream resumes, the patches here are
-designed to land as clean per-issue commits on `crazii/USBDDOS` with
-no rebasing required.
+**That situation has since changed.** Between May 13 and May 15, 2026,
+upstream resumed activity and merged every fix in this fork's
+`v1.0.0-alpha.1` patch series (PRs #22–#30 against `crazii/USBDDOS`).
+The fork's code-side mission is therefore complete — the patches are
+now upstream, where they belong.
+
+**The fork continues to exist as a binary-hosting layer.** Many
+real-hardware users of legacy DOS USB don't compile their own
+drivers, and upstream doesn't publish pre-built binaries. This fork
+publishes binary releases (built from upstream master, reproducible
+by anyone with Open Watcom v2 or DJGPP) as a convenience for testers
+and end users. It also remains a staging area for fixes that haven't
+yet been written or upstreamed (see "What this fork does NOT do" for
+the current known-unimplemented list).
+
+If upstream begins publishing its own binary releases, this fork can
+sunset to read-only.
 
 ## Who this fork is for
 

--- a/RetroWav/Board/opl3.c
+++ b/RetroWav/Board/opl3.c
@@ -41,7 +41,7 @@
     并将在法律允许的最大范围内被起诉。
 */
 
-#include "RETROWAV/BOARD/OPL3.h"
+#include "RetroWav/Board/opl3.h"
 
 static const int transfer_speed = 2e6;
 

--- a/RetroWav/Board/opl3.h
+++ b/RetroWav/Board/opl3.h
@@ -43,7 +43,7 @@
 
 #pragma once
 
-#include "RetroWav/RetroWav.h"
+#include "RetroWav/retrowav.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/RetroWav/Platform/dos_cdc.h
+++ b/RetroWav/Platform/dos_cdc.h
@@ -9,8 +9,8 @@
 
 #include <errno.h>
 
-#include "RetroWav/RetroWav.h"
-#include "RetroWav/Protocol/Serial.h"
+#include "RetroWav/retrowav.h"
+#include "RetroWav/Protocol/serial.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/RetroWav/Protocol/serial.c
+++ b/RetroWav/Protocol/serial.c
@@ -42,7 +42,7 @@
     并将在法律允许的最大范围内被起诉。
 */
 
-#include "Retrowav/Protocol/Serial.h"
+#include "RetroWav/Protocol/serial.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/RetroWav/retrowav.c
+++ b/RetroWav/retrowav.c
@@ -42,7 +42,7 @@
     并将在法律允许的最大范围内被起诉。
 */
 
-#include "RetroWav/RetroWav.h"
+#include "RetroWav/retrowav.h"
 #include <assert.h>
 
 #define RETROWAVE_CMD_BUFFER_SIZE 110

--- a/USBDDOS/CLASS/hub.c
+++ b/USBDDOS/CLASS/hub.c
@@ -73,14 +73,18 @@ static BOOL HUB_SetPortStatus(HCD_HUB* pHub, uint8_t port, uint16_t status)
     {
         _LOG("HUB port %d resetting\n", port);
         result = USB_HUB_SetPortFeature(HC2USB(pHub->pDevice), port, PORT_RESET) && result;
-        delay(55); //apply reset signal for 10ms+
-        result = USB_HUB_ClearPortFeature(HC2USB(pHub->pDevice), port, PORT_RESET) && result; //release reset signal
+        delay(55); //apply reset signal for 10ms+. Per USB 2.0 11.5.1.5 the hub auto-releases reset after the duration; software does not.
+        //Wait for the hub to complete the reset (PS_RESET self-clears). Bounded retry: 100 iterations * delay(5) = ~500ms cap.
+        int timeout = 100;
         do
         {
             delay(5);
             USB_HUB_PS ps; ps.val = USB_HUB_GetPortStatus(HC2USB(pHub->pDevice), port);
             current = ps.bm.status;
-        } while((current&PS_RESET)); //wait until reset is actually done. this also reload the current states
+        } while((current&PS_RESET) && --timeout > 0); //wait until reset is actually done. this also reload the current states
+        //Acknowledge the port-reset change indicator (USB 2.0 spec 11.24.2 Table 11-17: C_PORT_RESET is the valid clear-side selector).
+        //The original code used ClearPortFeature(PORT_RESET) which is NOT a valid ClearPortFeature selector per spec and STALLs on compliant hubs.
+        result = USB_HUB_ClearPortFeature(HC2USB(pHub->pDevice), port, C_PORT_RESET) && result;
 
         _LOG("HUB port %d reset %x\n", port, current);
     }
@@ -186,7 +190,7 @@ BOOL USB_HUB_InitDevice(USB_Device* pDevice)
     delay(55);
 
     {for(uint8_t i = 0; i < desc.bNbrPorts; ++i)
-        USB_HUB_ClearPortFeature(pDevice, i, PORT_RESET);}
+        USB_HUB_ClearPortFeature(pDevice, i, C_PORT_RESET);} //ack the port-reset change indicator. Spec: C_PORT_RESET is the valid clear-side selector (was PORT_RESET, which STALLs on compliant hubs).
     delay(55);
 
     //disable

--- a/USBDDOS/DPMI/dpmi_dj2.c
+++ b/USBDDOS/DPMI/dpmi_dj2.c
@@ -307,6 +307,15 @@ void* DPMI_DMAMalloc(unsigned int size, unsigned int alignment/* = 4*/)
 
 void* DPMI_DMAMallocNCPB(unsigned int size, unsigned int alignment/* = 4*/)
 {
+    /* Gap H: page-crossing check must be performed in LINEAR address space,
+     * not C-pointer-relative space.  Under HDPMI32 (and any DPMI host that
+     * returns a non-page-aligned segment base for the XMS mapping), the
+     * mspace C-pointers and the linear addresses have a non-zero phase
+     * difference: C-pointer pages start at one grid, linear pages start at
+     * another offset by (DPMI_DSBase & 0xFFF).  An allocation that fits
+     * within one C-pointer page can still straddle a linear page boundary,
+     * which is what the hardware sees for DMA.  Translate via DPMI_DSBase
+     * before the boundary test. */
     #if DEBUG
     CLIS();
     XMS_Allocated += size;
@@ -315,13 +324,19 @@ void* DPMI_DMAMallocNCPB(unsigned int size, unsigned int alignment/* = 4*/)
     uint32_t offset = align(addr, alignment) - addr;
 
     uint32_t extra = 0;
-    while(((addr+offset+extra)&~0xFFF) != ((addr+offset+extra+size)&~0xFFF))
     {
-        extra += align(size, alignment);
-        mspace_free(XMS_Space, ptr-8);
-        ptr = (uint8_t*)mspace_malloc(XMS_Space, size+alignment+extra+8) + 8;
-        addr = (uintptr_t)ptr;
-        offset = align(addr, alignment) - addr + extra;
+        uint32_t lin_start = DPMI_DSBase + (uint32_t)(addr + offset + extra);
+        uint32_t lin_end   = lin_start + size;
+        while((lin_start & ~0xFFFUL) != (lin_end & ~0xFFFUL))
+        {
+            extra += align(size, alignment);
+            mspace_free(XMS_Space, ptr-8);
+            ptr = (uint8_t*)mspace_malloc(XMS_Space, size+alignment+extra+8) + 8;
+            addr = (uintptr_t)ptr;
+            offset = align(addr, alignment) - addr + extra;
+            lin_start = DPMI_DSBase + (uint32_t)(addr + offset + extra);
+            lin_end   = lin_start + size;
+        }
     }
 
     uint32_t* uptr = (uint32_t*)(ptr + offset);
@@ -337,8 +352,15 @@ void* DPMI_DMAMallocNCPB(unsigned int size, unsigned int alignment/* = 4*/)
     void* tries[TRY] = {0};
     tries[0] = mspace_memalign(XMS_Space, alignment, size);
     int i = 0;
-    while(i<TRY && ((align((uintptr_t)tries[i],alignment))&~0xFFFUL) != ((align((uintptr_t)tries[i],alignment)+size-1)&~0xFFFUL))
-        tries[++i] = mspace_memalign(XMS_Space, alignment, size);
+    {
+        uint32_t lin_start = DPMI_DSBase + (uint32_t)align((uintptr_t)tries[0], alignment);
+        while(i<TRY && (lin_start & ~0xFFFUL) != ((lin_start + size - 1) & ~0xFFFUL))
+        {
+            tries[++i] = mspace_memalign(XMS_Space, alignment, size);
+            if(!tries[i]) break;
+            lin_start = DPMI_DSBase + (uint32_t)align((uintptr_t)tries[i], alignment);
+        }
+    }
     if(i == TRY)
     {
         assert(FALSE);

--- a/USBDDOS/HCD/hcd.c
+++ b/USBDDOS/HCD/hcd.c
@@ -87,21 +87,25 @@ BOOL HCD_RemoveDevice(HCD_Device* pDevice)
 
     assert(pDevice->pRequest == NULL);
 
-    BOOL result = pDevice->pHub->SetPortStatus(pDevice->pHub, pDevice->bHubPort, USB_PORT_RESET); //No need to do that, but do it for safety
-    assert(result);
-    result = result && pDevice->pHub->SetPortStatus(pDevice->pHub, pDevice->bHubPort, USB_PORT_DISABLE);
-    assert(result);
-    result = result && pDevice->pHCI->pHCDMethod->RemoveDevice(pDevice);
-    assert(result);
+    //Best-effort cleanup. SetPortStatus/HCDMethod failures during teardown are logged
+    //but not fatal: the device must be removed from the HCD DeviceList regardless, or
+    //subsequent enumeration sees a stale entry and triggers worse misbehavior. Each
+    //step runs unconditionally so a failure early in the chain doesn't skip later steps.
+    BOOL portReset = pDevice->pHub->SetPortStatus(pDevice->pHub, pDevice->bHubPort, USB_PORT_RESET); //No need to do that, but do it for safety
+    if(!portReset) _LOG("HCD_RemoveDevice: port %d reset failed during teardown\n", pDevice->bHubPort);
+    BOOL portDisable = pDevice->pHub->SetPortStatus(pDevice->pHub, pDevice->bHubPort, USB_PORT_DISABLE);
+    if(!portDisable) _LOG("HCD_RemoveDevice: port %d disable failed during teardown\n", pDevice->bHubPort);
+    BOOL hcdRemove = pDevice->pHCI->pHCDMethod->RemoveDevice(pDevice);
+    if(!hcdRemove) _LOG("HCD_RemoveDevice: HCI method RemoveDevice failed during teardown\n");
 
-    if(result)
-    {
-        memmove(&pDevice->pHCI->DeviceList[i],&pDevice->pHCI->DeviceList[i+1],(pDevice->pHCI->bDevCount-i-1)*sizeof(HCD_Device*));
-        pDevice->pHCI->DeviceList[--pDevice->pHCI->bDevCount] = NULL;
-        pDevice->pHCData = NULL;
-        pDevice->pHCI = NULL;
-    }
-    return result;
+    //Always remove from device list — even if some cleanup steps failed.
+    //Leaving a half-removed device in the list is strictly worse than partial cleanup.
+    memmove(&pDevice->pHCI->DeviceList[i],&pDevice->pHCI->DeviceList[i+1],(pDevice->pHCI->bDevCount-i-1)*sizeof(HCD_Device*));
+    pDevice->pHCI->DeviceList[--pDevice->pHCI->bDevCount] = NULL;
+    pDevice->pHCData = NULL;
+    pDevice->pHCI = NULL;
+
+    return portReset && portDisable && hcdRemove;
 }
 
 HCD_Request* HCD_AddRequest(HCD_Device* pDevice, void* pEndpoint, HCD_TxDir dir, void* pBuffer, uint16_t size, uint8_t endpoint, HCD_COMPLETION_CB pFnCB, void* pCallbackData)

--- a/USBDDOS/HCD/hcd.h
+++ b/USBDDOS/HCD/hcd.h
@@ -1,7 +1,7 @@
 #ifndef _HCD_H_
 #define _HCD_H_ 1
 #include "USBDDOS/platform.h"
-#include "USBDDOS/USBCFG.H"
+#include "USBDDOS/usbcfg.h"
 #include "USBDDOS/pci.h"
 
 //host controler driver generic

--- a/USBDDOS/HCD/ohci.c
+++ b/USBDDOS/HCD/ohci.c
@@ -202,9 +202,51 @@ BOOL OHCI_ISR(HCD_Interface* pHCI)
         DPMI_StoreD(dwIOBase + HcInterruptStatus, StartofFrame);
         context &= ~StartofFrame;
     }
-    if(context & UnrecoverableError) // need reset
+    if(context & UnrecoverableError) // OHCI spec 5.3.1.1: reset and reinit
     {
-        //return TRUE;
+        /* PATCHED: was empty. Was a real bug for NEC OHCI which is known
+         * to raise spurious UEs (Linux applies OHCI_QUIRK_NEC for this).
+         * Recovery: full host-controller reset, then restore the
+         * operational registers from the values we know we set during
+         * InitController. Pending transfers will fail at the class-driver
+         * layer; callers are expected to retry. */
+        _LOG("OHCI: UnrecoverableError, resetting controller\n");
+
+        /* Save BIOS-detected frame interval (HCR resets it to default). */
+        uint32_t FrameInterval = DPMI_LoadD(dwIOBase + HcFmInterval);
+
+        /* Issue host controller reset; HCR self-clears within 10us per spec. */
+        DPMI_StoreD(dwIOBase + HcCommandStatus, HostControllerReset);
+
+        /* Bounded busy-wait (no delay() in ISR context). 10us typical,
+         * give a generous ~1ms safety margin via 1000 polls. */
+        int spin = 1000;
+        while(spin-- > 0 && (DPMI_LoadD(dwIOBase + HcCommandStatus) & HostControllerReset))
+            ;
+
+        /* Restore operational registers (HCR clears them). */
+        DPMI_StoreD(dwIOBase + HcFmInterval, FrameInterval);
+        DPMI_StoreD(dwIOBase + HcHCCA, DPMI_PTR2P(&pHCDData->HCCA));
+        DPMI_StoreD(dwIOBase + HcControlHeadED, DPMI_PTR2P(&pHCDData->ControlHead));
+        DPMI_StoreD(dwIOBase + HcBulkHeadED, DPMI_PTR2P(&pHCDData->BulkHead));
+        DPMI_StoreD(dwIOBase + HcPeriodicStart, (FrameInterval & 0x3FFF) * 9 / 10);
+
+        /* Re-enable the same interrupt set we configured in InitController.
+         * HcInterruptEnable is write-1-to-set, so this enables those bits. */
+        DPMI_StoreD(dwIOBase + HcInterruptEnable,
+                    (0x4000003FL & ~StartofFrame) | MasterInterruptEnable);
+
+        /* Re-enable list processing in HcControl, then go USBOPERATIONAL. */
+        DPMI_MaskD(dwIOBase + HcControl, ~InterruptRouting, 0UL);
+        DPMI_MaskD(dwIOBase + HcControl, ~0UL,
+                   ControlListEnable | PeriodicListEnable |
+                   IsochronousEnable | BulkListEnable);
+        DPMI_MaskD(dwIOBase + HcControl, ~HostControllerFunctionalState,
+                   (USBOPERATIONAL << HostControllerFunctionalState_SHIFT));
+
+        /* Clear UE status so it doesn't perpetually re-fire. */
+        DPMI_StoreD(dwIOBase + HcInterruptStatus, UnrecoverableError);
+        context &= ~UnrecoverableError;
     }
     if(context & ScheduleOverrun) // TODO:
     {

--- a/USBDDOS/HCD/ohci.c
+++ b/USBDDOS/HCD/ohci.c
@@ -115,6 +115,19 @@ BOOL OHCI_InitController(HCD_Interface* pHCI, PCI_DEVICE* pPCIDev)
         //HCFS = (DPMI_LoadD(dwBase + HcControl) & HostControllerFunctionalState) >> HostControllerFunctionalState_SHIFT;
         //_LOG("HCFS: %d\n", HCFS);
     }
+
+    /* Gap 5: disable OHCI Legacy Support emulation now that we've taken
+     * ownership. On chips that implement Legacy Support (NEC µPD720101,
+     * SiS 7001, etc.), BIOS may have left the keyboard/mouse PS/2-style
+     * emulation active. With our driver running, that emulation can
+     * spuriously generate interrupts or compete for the same MMIO state.
+     * Writing 0 to HceControl clears EmulationEnable (and all other
+     * Legacy Support state). Per OHCI 1.0a Appendix B, HceControl is
+     * at MMIO 0x100; on chips without Legacy Support the offset is
+     * reserved/RAZ and the write is silently ignored, so this is
+     * universally safe. */
+    DPMI_StoreD(dwBase + HceControl, 0);
+
     /* Gap 6: read-modify-write of HcFmInterval to preserve the BIOS-tuned
      * value across the soft reset. On ALi M5237 (and other chips matching
      * OHCI_HasFmIntervalLockup), reading HcFmInterval locks the entire

--- a/USBDDOS/HCD/ohci.c
+++ b/USBDDOS/HCD/ohci.c
@@ -163,8 +163,9 @@ BOOL OHCI_InitController(HCD_Interface* pHCI, PCI_DEVICE* pPCIDev)
     memset(pHCDData, 0, sizeof(OHCI_HCData));
     _LOG("HCDDData %08x, Initial memory usage: %d\n", pHCDData, sizeof(OHCI_HCData));
 
-    // port power on
-    if(DPMI_LoadD(dwBase + HcRhDescriptorA) & PowerSwitchingMode)
+    // port power on, then wait POTPGT*2ms before accessing the ports
+    uint32_t rh_desc_a = DPMI_LoadD(dwBase + HcRhDescriptorA);
+    if(rh_desc_a & PowerSwitchingMode)
     { // per-port power
         for (uint32_t i = 0; i < pHCI->bNumPorts; i++)
             DPMI_MaskD(dwBase + HcRhPort1Status + i * 4, ~0UL, SetPortPower);
@@ -172,6 +173,23 @@ BOOL OHCI_InitController(HCD_Interface* pHCI, PCI_DEVICE* pPCIDev)
     else
     { // all-port power
         DPMI_MaskD(dwBase + HcRhStatus, ~0UL, SetGlobalPower);
+    }
+    /* Gap 8: wait POTPGT * 2ms before accessing ports.
+     * OHCI 1.0a 7.4.1: PowerOnToPowerGoodTime (HcRhDescriptorA bits 31:24)
+     * specifies the time in 2ms units that must elapse after enabling port
+     * power before software may access the port. NEC µPD720101 default
+     * POTPGT = 0x0F = 30ms (manual section 4.2); SiS 7001 = 0x01 = 2ms.
+     * Without this wait, GetPortStatus may return stale values on slower
+     * silicon, causing flaky enumeration.
+     *
+     * CRITICAL: mask with 0xFF before multiplying. POTPGT is an 8-bit field;
+     * without the mask a right-shift of a signed value with the top bit set
+     * could sign-extend to 0xFFFFFFFF, multiplying to a ~50-day delay
+     * (FYSOS Book 8 documents this trap). */
+    {
+        uint32_t potpgt = (rh_desc_a >> 24) & 0xFFUL;
+        if(potpgt > 0)
+            delay(potpgt * 2);
     }
     // hcca & queue heads
     OHCI_BuildHCCA(pHCDData);

--- a/USBDDOS/HCD/ohci.c
+++ b/USBDDOS/HCD/ohci.c
@@ -109,8 +109,16 @@ BOOL OHCI_InitController(HCD_Interface* pHCI, PCI_DEVICE* pPCIDev)
         else if(HCFS == USBRESET)
         { // take ownership from SMM driver
             DPMI_MaskD(dwBase + HcCommandStatus, ~0UL, OwnershipChangeRequest);
-            while(DPMI_LoadD(dwBase + HcControl) & InterruptRouting) // wait SMM driver
+            /* Gap 3: bound the SMM handoff wait. Some BIOSes never relinquish
+             * (locked SMM, BIOS bug); the original unbounded while loop hangs
+             * USBDDOS forever in that case. Linux's quirk_usb_handoff_ohci
+             * uses a comparable 500ms cap and proceeds with a warning; we
+             * give ~1s (20 * 50ms) of headroom for slow BIOSes. */
+            int spin;
+            for(spin = 20; spin > 0 && (DPMI_LoadD(dwBase + HcControl) & InterruptRouting); --spin)
                 delay(50);
+            if(spin == 0)
+                _LOG("OHCI: SMM handoff timeout after 1s, proceeding anyway (BIOS bug?)\n");
         }
         //HCFS = (DPMI_LoadD(dwBase + HcControl) & HostControllerFunctionalState) >> HostControllerFunctionalState_SHIFT;
         //_LOG("HCFS: %d\n", HCFS);

--- a/USBDDOS/HCD/ohci.c
+++ b/USBDDOS/HCD/ohci.c
@@ -10,6 +10,31 @@
 
 // ref: OHCI_Specification_Rev.1.0a
 
+/* Gap H: OHCI DMA structures (HCCA, EDs, TDs) must not span 4KB page
+ * boundaries.  The OHCI hardware DMA-accesses these as units and the
+ * spec does NOT support split pages for the structures themselves
+ * (only for data buffers, which have a separate CBP/BE mechanism in
+ * the TD that explicitly supports a single page-boundary crossing,
+ * per OHCI 1.0a section 3.1.1.1).
+ *
+ * The HCData allocation is the highest-risk site: it embeds the
+ * 256-byte HCCA plus 8 static EDs (~548 bytes total), and a plain
+ * DPMI_DMAMalloc could place it straddling a 4KB page boundary,
+ * silently breaking DMA for either the HCCA or the static EDs.
+ *
+ * EHCI has used this macro-override pattern (ehci.c:25-30) since
+ * EHCI bring-up; OHCI catches up here.
+ */
+#define DPMI_DMAMalloc DPMI_DMAMallocNCPB
+#ifdef USB_TAlloc
+#undef USB_TAlloc
+#endif
+#define USB_TAlloc DPMI_DMAMallocNCPB
+#ifdef USB_TAlloc32
+#undef USB_TAlloc32
+#endif
+#define USB_TAlloc32(size) DPMI_DMAMallocNCPB((size), 32)
+
 // configs
 #define TIME_OUT 500L
 
@@ -197,6 +222,24 @@ BOOL OHCI_InitController(HCD_Interface* pHCI, PCI_DEVICE* pPCIDev)
     //_LOG("HCCA: %04x %08lx\n", &pHCDData->HCCA, DPMI_PTR2P(&pHCDData->HCCA));
     assert((DPMI_PTR2P(&pHCDData->HCCA) & 0xFF) == 0); // ensure alignment
     assert((DPMI_PTR2P(&pHCDData->ControlHead) & 0xF) == 0);
+    /* Gap H: defense-in-depth checks that DPMI_DMAMallocNCPB (substituted
+     * via the macro at top of file) actually produced a non-page-crossing
+     * allocation.  HCCA is the DMA-critical block (256 bytes, OHCI hw reads
+     * the entire structure as a unit); the static EDs (ControlHead through
+     * ED1ms) each individually fit in their own page by 16-byte alignment
+     * but are tested as a region to confirm the whole HCData footprint is
+     * page-contained.  Assertion-only (compiled out under NDEBUG); the real
+     * fix is the macro substitution. */
+#if DEBUG
+    {
+        uint32_t hccaStart = DPMI_PTR2P(&pHCDData->HCCA);
+        uint32_t hccaEnd   = hccaStart + sizeof(OHCI_HCCA_BLOCK) - 1;
+        assert((hccaStart & ~0xFFFUL) == (hccaEnd & ~0xFFFUL));
+        uint32_t hcdStart  = DPMI_PTR2P(pHCDData);
+        uint32_t hcdEnd    = hcdStart + sizeof(OHCI_HCData) - 1;
+        assert((hcdStart & ~0xFFFUL) == (hcdEnd & ~0xFFFUL));
+    }
+#endif
 
     pHCDData->ControlHead.ControlBits.Skip = 1;
     DPMI_StoreD(dwBase + HcControlHeadED, DPMI_PTR2P(&pHCDData->ControlHead));

--- a/USBDDOS/HCD/ohci.c
+++ b/USBDDOS/HCD/ohci.c
@@ -13,6 +13,31 @@
 // configs
 #define TIME_OUT 500L
 
+/* OHCI 1.0a default FrameInterval (12000 bits per frame minus 1).
+ * Used as a substitute value on chips where reading HcFmInterval is
+ * unsafe (see OHCI_HasFmIntervalLockup below). */
+#define OHCI_FI_DEFAULT 0x2EDF
+
+/* Gap 6 quirk: PCI IDs of OHCI controllers whose HcFmInterval register
+ * locks the entire system on access. Modeled on Linux's no_fminterval
+ * flag in quirk_usb_handoff_ohci (drivers/usb/host/pci-quirks.c).
+ *
+ * Currently known affected silicon:
+ *   ULi / ALi M5237  (PCI 10B9:5237) - the OHCI block inside the ALi
+ *                                       M1543C southbridge.
+ *
+ * The cost of skipping HcFmInterval read/restore is that the controller
+ * boots with its hardware-default value (FI = 0x2EDF) rather than any
+ * BIOS-tuned value. Linux accepts this trade-off; we do too.
+ *
+ * Add more matches here if other affected silicon is identified.
+ */
+static inline BOOL OHCI_HasFmIntervalLockup(HCD_Interface* pHCI)
+{
+    return (pHCI->PCI.Header.VendorID == 0x10B9 &&
+            pHCI->PCI.Header.DeviceID == 0x5237);
+}
+
 static void OHCI_ISR_ProcessDoneQueue(HCD_Interface* pHCI, uint32_t dwDoneHead);
 static uint16_t OHCI_GetPortStatus(HCD_Interface* pHCI, uint8_t port);
 static BOOL OHCI_SetPortStatus(HCD_Interface* pHCI, uint8_t port, uint16_t status);
@@ -90,10 +115,22 @@ BOOL OHCI_InitController(HCD_Interface* pHCI, PCI_DEVICE* pPCIDev)
         //HCFS = (DPMI_LoadD(dwBase + HcControl) & HostControllerFunctionalState) >> HostControllerFunctionalState_SHIFT;
         //_LOG("HCFS: %d\n", HCFS);
     }
-    uint32_t FrameInterval = DPMI_LoadD(dwBase + HcFmInterval);
+    /* Gap 6: read-modify-write of HcFmInterval to preserve the BIOS-tuned
+     * value across the soft reset. On ALi M5237 (and other chips matching
+     * OHCI_HasFmIntervalLockup), reading HcFmInterval locks the entire
+     * system, so skip the read/restore and accept the post-reset default. */
+    BOOL bSkipFmInterval = OHCI_HasFmIntervalLockup(pHCI);
+    if(bSkipFmInterval)
+        _LOG("OHCI: HcFmInterval lockup quirk active (PCI %04x:%04x), using spec default %04xh\n",
+             pHCI->PCI.Header.VendorID, pHCI->PCI.Header.DeviceID, OHCI_FI_DEFAULT);
+
+    uint32_t FrameInterval = bSkipFmInterval
+        ? OHCI_FI_DEFAULT
+        : DPMI_LoadD(dwBase + HcFmInterval);
     DPMI_MaskD(dwBase + HcCommandStatus, ~0UL, HostControllerReset);
     delay(1); //10us max
-    DPMI_StoreD(dwBase + HcFmInterval, FrameInterval);
+    if(!bSkipFmInterval)
+        DPMI_StoreD(dwBase + HcFmInterval, FrameInterval);
 
     // get ports
     pHCI->bNumPorts = DPMI_LoadB(dwBase + HcRhDescriptorA); // low 8bit of a register
@@ -212,8 +249,12 @@ BOOL OHCI_ISR(HCD_Interface* pHCI)
          * layer; callers are expected to retry. */
         _LOG("OHCI: UnrecoverableError, resetting controller\n");
 
-        /* Save BIOS-detected frame interval (HCR resets it to default). */
-        uint32_t FrameInterval = DPMI_LoadD(dwIOBase + HcFmInterval);
+        /* Save BIOS-detected frame interval (HCR resets it to default).
+         * Gap 6: skip on chips where HcFmInterval access locks the system. */
+        BOOL bSkipFmIntervalISR = OHCI_HasFmIntervalLockup(pHCI);
+        uint32_t FrameInterval = bSkipFmIntervalISR
+            ? OHCI_FI_DEFAULT
+            : DPMI_LoadD(dwIOBase + HcFmInterval);
 
         /* Issue host controller reset; HCR self-clears within 10us per spec. */
         DPMI_StoreD(dwIOBase + HcCommandStatus, HostControllerReset);
@@ -224,8 +265,10 @@ BOOL OHCI_ISR(HCD_Interface* pHCI)
         while(spin-- > 0 && (DPMI_LoadD(dwIOBase + HcCommandStatus) & HostControllerReset))
             ;
 
-        /* Restore operational registers (HCR clears them). */
-        DPMI_StoreD(dwIOBase + HcFmInterval, FrameInterval);
+        /* Restore operational registers (HCR clears them).
+         * Gap 6: skip HcFmInterval restore on quirked chips. */
+        if(!bSkipFmIntervalISR)
+            DPMI_StoreD(dwIOBase + HcFmInterval, FrameInterval);
         DPMI_StoreD(dwIOBase + HcHCCA, DPMI_PTR2P(&pHCDData->HCCA));
         DPMI_StoreD(dwIOBase + HcControlHeadED, DPMI_PTR2P(&pHCDData->ControlHead));
         DPMI_StoreD(dwIOBase + HcBulkHeadED, DPMI_PTR2P(&pHCDData->BulkHead));

--- a/USBDDOS/HCD/ohci.c
+++ b/USBDDOS/HCD/ohci.c
@@ -209,6 +209,41 @@ BOOL OHCI_InitController(HCD_Interface* pHCI, PCI_DEVICE* pPCIDev)
     pHCDData->ED4msTail = &pHCDData->ED4ms;
     pHCDData->ED2msTail = &pHCDData->ED2ms;
     pHCDData->ED1msTail = &pHCDData->ED1ms;
+
+    /* Gap 2: INITRESET-equivalent verify and one-shot retry.
+     * Some OPTi 82C861 (FireLink) and certain SiS chips don't honor
+     * HcFmInterval / HcPeriodicStart writes while in the post-HCR SUSPEND
+     * state - the register reads back as zero in the FSMPS or FrameInterval
+     * field. Mirrors Linux's OHCI_QUIRK_INITRESET handling
+     * (drivers/usb/host/ohci-hcd.c around the "retry:" label). On failure,
+     * HC-reset again and transition to USBOPERATIONAL state BEFORE
+     * re-writing FmInterval / PeriodicStart so the chip accepts the write. */
+    {
+        uint32_t fi = DPMI_LoadD(dwBase + HcFmInterval);
+        uint32_t ps = DPMI_LoadD(dwBase + HcPeriodicStart);
+        if((fi & 0x3FFF0000UL) == 0 || ps == 0)
+        {
+            _LOG("OHCI: FmInterval=%08lx PeriodicStart=%08lx didn't latch; INITRESET retry\n", (unsigned long)fi, (unsigned long)ps);
+            DPMI_MaskD(dwBase + HcCommandStatus, ~0UL, HostControllerReset);
+            delay(1);
+            /* INITRESET quirk: USBOPERATIONAL state FIRST, BEFORE FmInterval write */
+            DPMI_MaskD(dwBase + HcControl, ~HostControllerFunctionalState,
+                       (USBOPERATIONAL << HostControllerFunctionalState_SHIFT));
+            /* Re-establish state cleared by HCR */
+            if(!bSkipFmInterval)
+                DPMI_StoreD(dwBase + HcFmInterval, FrameInterval);
+            DPMI_StoreD(dwBase + HcHCCA, DPMI_PTR2P(&pHCDData->HCCA));
+            DPMI_StoreD(dwBase + HcControlHeadED, DPMI_PTR2P(&pHCDData->ControlHead));
+            DPMI_StoreD(dwBase + HcBulkHeadED, DPMI_PTR2P(&pHCDData->BulkHead));
+            DPMI_StoreD(dwBase + HcInterruptEnable, (0x4000003FL & ~StartofFrame) | MasterInterruptEnable);
+            DPMI_MaskD(dwBase + HcControl, ~0UL, ControlListEnable | PeriodicListEnable | IsochronousEnable | BulkListEnable);
+            DPMI_StoreD(dwBase + HcPeriodicStart, (FrameInterval & 0x3FFF) * 9 / 10);
+            fi = DPMI_LoadD(dwBase + HcFmInterval);
+            ps = DPMI_LoadD(dwBase + HcPeriodicStart);
+            if((fi & 0x3FFF0000UL) == 0 || ps == 0)
+                _LOG("OHCI: still won't latch after INITRESET retry, proceeding anyway\n");
+        }
+    }
     return TRUE;
 }
 

--- a/USBDDOS/HCD/ohci.h
+++ b/USBDDOS/HCD/ohci.h
@@ -83,6 +83,13 @@
 #define PortOverCurrentIndicatorChange BIT19
 #define PortResetStatusChange   BIT20
 
+//OHCI 1.0a Appendix B Legacy Support Interface Specification.
+//Implemented on chips with Legacy keyboard/mouse emulation (NEC µPD720101,
+//SiS 7001, etc.). Reserved/RAZ on non-Legacy-Support implementations -
+//writes are silently ignored.
+#define HceControl              0x100L
+#define EmulationEnable         BIT0
+
 #define PIDFROMTD               0 //for control ED PID
 #define PIDSETUP                0
 #define PIDOUT                  1

--- a/USBDDOS/dbgutil.c
+++ b/USBDDOS/dbgutil.c
@@ -139,7 +139,15 @@ void DBG_Logv(const char* fmt, va_list aptr)
     len = min(len, SIZE-1);
     buf[len] = '\0';
 
-    #if 0
+    /* COM1 logging path. Enabled in this fork (was #if 0 upstream) so
+     * headless emulator runs and serial-console real-hardware testing can
+     * capture _LOG output without a VGA screen. Bret-Johnson-style serial
+     * output: drain the UART transmit-holding-register-empty status bit
+     * (LSR bit 5 at port 0x3F8+5) before writing each byte to the
+     * transmitter (port 0x3F8). The early return then skips the upstream
+     * VGA/INT-10h paths below, which keeps timing predictable on
+     * USBDDOSP regression captures. */
+    #if 1
     outp(0x3F8+3, 0x03);
     for(int i = 0; i < len; ++i)
     {

--- a/USBDDOS/usballoc.c
+++ b/USBDDOS/usballoc.c
@@ -54,7 +54,13 @@ static USBALLOC_Memory* USBALLOC_GetMemory(void)
             assert(memory->arena != NULL);
             #else
             assert(memory->arena == NULL);
-            memory->arena = (uint8_t*)DPMI_DMAMalloc(USBALLOC_MEMORY_SIZE, 32); //alignment to 32 for EHCI
+            /* Gap H: pool arenas are sliced into 32-byte HC structures (TDs, EDs)
+             * for OHCI and EHCI consumers via USB_TAlloc*.  An arena that straddles
+             * a 4KB page boundary would silently make some of its sub-slices span
+             * pages too -- broken for OHCI DMA per spec section 4.2.2.
+             * USBALLOC_MEMORY_SIZE (1KB) fits in a single page so NCPB always
+             * succeeds within its retry budget. */
+            memory->arena = (uint8_t*)DPMI_DMAMallocNCPB(USBALLOC_MEMORY_SIZE, 32);
             #endif
             //_LOG("memory arena: %08lx\n", ((uint32_t)(memory->arena)));
             assert((((uint32_t)(memory->arena))&0x1F) == 0);
@@ -86,7 +92,9 @@ void USBALLOC_Init(void)
 #if USBALLOC_PREALLOC
     for(int i = 0; i < USBALLOC_MEMORY_COUNT; ++i)
     {
-        USBALLOC_Pool[i].arena = (uint8_t*)DPMI_DMAMalloc(USBALLOC_MEMORY_SIZE, 32);
+        //Gap H: see comment in USBALLOC_GetMemory above. NCPB applies to the
+        //pre-allocated path too.
+        USBALLOC_Pool[i].arena = (uint8_t*)DPMI_DMAMallocNCPB(USBALLOC_MEMORY_SIZE, 32);
         assert(USBALLOC_Pool[i].arena);
     }
 #endif

--- a/main.c
+++ b/main.c
@@ -21,9 +21,9 @@
 #endif
 
 #if ENABLE_RETROWAVE
-#include "RetroWav/RetroWav.h"
+#include "RetroWav/retrowav.h"
 #include "RetroWav/Platform/dos_cdc.h"
-#include "RetroWav/Board/OPL3.h"
+#include "RetroWav/Board/opl3.h"
 #include "emm.h"
 #include "hdpmipt.h"
 


### PR DESCRIPTION
# PR #32 — Enforce no-page-crossing for OHCI DMA structures + fix `DPMI_DMAMallocNCPB`

## Summary

Three coordinated changes addressing the OHCI DMA-structure page-crossing concern, plus a fix to the existing `DPMI_DMAMallocNCPB` allocator that was checking page boundaries in the wrong address space.

- `USBDDOS/HCD/ohci.c` — Apply the `DPMI_DMAMalloc → DPMI_DMAMallocNCPB` macro override at the top of the file, mirroring the pattern EHCI has used since its bring-up (`ehci.c:25-30`).
- `USBDDOS/HCD/ohci.c` — Add a DEBUG-build defense-in-depth assertion at the HCCA register-write site verifying the produced allocation actually fits within a single physical page.
- `USBDDOS/usballoc.c` — Switch pool-arena allocations (both the on-demand `USBALLOC_GetMemory` path and the `USBALLOC_Init` pre-allocation path) from `DPMI_DMAMalloc` to `DPMI_DMAMallocNCPB`. Variable-size paths remain on plain `DMAMalloc`.
- `USBDDOS/DPMI/dpmi_dj2.c` — **Fix `DPMI_DMAMallocNCPB` to perform its page-crossing check in linear-address space rather than C-pointer space.** This is a real bug uncovered by the defense-in-depth assertion above.

## Motivation

OHCI EDs, TDs, the HCCA, and ISO TDs must be contiguous within a single 4KB physical page — the OHCI hardware DMA-accesses these as units. The spec (OHCI 1.0a §§ 4.2.2, 4.3.1) does not provide a "split-page" descriptor mechanism for the structures themselves, only for data buffers (§ 3.1.1.1 supports a single page-boundary crossing via the TD's `CBP`/`BE` pair).

For 32-byte structures (ED, TD, ISO_TD) with appropriate alignment, a single allocation cannot span a page boundary — alignment ≤ size ≤ 4096 always fits. The issue is the **`OHCI_HCData`** allocation: it embeds the 256-byte HCCA plus 8 static EDs (`ControlHead`, `BulkHead`, `ED32ms` through `ED1ms`), totaling ~548 bytes. A 548-byte allocation with 256-byte alignment can land at offsets within a page where it straddles into the next page, silently breaking DMA for either the HCCA (which the hardware reads via the `HcHCCA` register) or the static EDs (whose physical addresses are linked into the HCCA's interrupt table).

EHCI handles this with a top-of-file macro override:

```c
//EHCI spec (chapter 3) require structures NOT to span across page boundary
#define DPMI_DMAMalloc DPMI_DMAMallocNCPB
#define USB_TAlloc DPMI_DMAMallocNCPB
```

OHCI does not. This PR adds it.

## The deeper bug in `DPMI_DMAMallocNCPB`

While verifying the macro override worked, a defense-in-depth assertion added at the `HcHCCA` register-write site fired in QEMU:

```
HCDDData 000c1200, Initial memory usage: 548
Assertion failed at ../USBDDOS/HCD/ohci.c line 240, function OHCI_InitController
: (hcdStart & ~0xFFFUL) == (hcdEnd & ~0xFFFUL)
```

The `pHCDData` C-pointer value `0x000c1200` lands within one C-pointer-relative page (`0x000c1000`–`0x000c1FFF`), so the existing NCPB retry loop accepted the allocation. But the **linear address** at that pointer is `DPMI_DSBase + 0x000c1200`, and under HDPMI32 the DS base is not 4KB-aligned (`XMS_Bias` of 4096 with an XMS heap mapped at a non-page-aligned base). Specifically from the QEMU run:

```
XMS base 005fcc00, XMS lbase 002e1c00 XMS heap base 000c0000
```

`XMS lbase` ends in `0xC00` — the heap's linear base is at a 0xC00 offset within its page. This means C-pointer-relative pages and linear pages live on different grids, offset by `(DPMI_DSBase & 0xFFF)`. The `pHCDData = 0x000c1200` allocation:

- C-pointer space: `0x000c1200` → `0x000c1423`, both in C-pointer page `0x000c1000`. NCPB previously accepted this.
- Linear space: `0x003a1e00` → `0x003a2023`, **crossing the linear page boundary at `0x003a2000`**.

The hardware sees linear addresses, not C-pointer values. The NCPB check must operate in linear space to do its job.

The fix translates `addr` via `DPMI_DSBase` before the boundary test in both the DEBUG and the NDEBUG paths of `DPMI_DMAMallocNCPB`.

**EHCI has been latently exposed to the same NCPB bug since its bring-up** but appears not to have been hit in practice — its DMA structures (QH 96B, QTD 32B, iTD 64B, etc.) are all small enough that the probability of accidentally crossing a linear page boundary is much lower than for OHCI's 548-byte HCData. The fix benefits both HCDs.

## Risk and scope

- **OHCI macro override** mirrors a proven EHCI pattern. No new code paths.
- **`usballoc.c` pool arenas** are 1KB (`USBALLOC_MEMORY_SIZE`), small enough that NCPB always succeeds within its retry budget.
- **Variable-size paths in `usballoc.c`** (the >512-byte transfer-buffer path at line 135) stay on plain `DMAMalloc` because OHCI § 3.1.1.1 explicitly supports buffers spanning one page boundary via `CBP`/`BE`.
- **NCPB fix** changes the boundary-check arithmetic only. The retry-loop structure, mspace_malloc/free pattern, and return contract are unchanged. NDEBUG path also fixed (was equivalent bug, just spelled differently).
- **No behavioral change for well-allocated allocations** — NCPB only retries when the placement is bad. Under HDPMI32 with a page-aligned DS base (which is the common case), the linear-address check and the old C-pointer check produce identical results.
- **DEBUG-only assertion** added to OHCI; compiles out under NDEBUG, so production binaries are unaffected by the assertion code.

## Testing

### QEMU OHCI + usb-audio (DJGPP DEBUG build, HDPMI32, FreeDOS 1.4)

**Without the NCPB fix** (and with just the macro override + assertion): assertion fires on every run because NCPB silently misses the linear-page crossing. Allocation lands at `pHCDData = 0x000c1200` (linear `0x003a1e00`, crossing `0x003a2000`).

**With the NCPB fix in place**: NCPB's retry loop correctly detects the linear-page crossing and retries. Allocation moves to `pHCDData = 0x000c1500` (linear `0x003a2100`, end `0x003a2323` — single page `0x003a2000`). Defense-in-depth assertion passes. Enumeration completes cleanly:

```
Host Controller: Bus:0, Dev:4, Func:0, pi:0x10, IRQ: 11, INT Pin: INTA#
OHCI BAR address: febb1000, mapped address 004b2000, size: 00000100
HCFS: 0
Numports: 3
HCDDData 000c1500, Initial memory usage: 548    ← moved by NCPB retry
Install ISR 0x73
Enumerate device for OHCI ROOT HUB on Bus:Dev:Func 00:04:00
Enumerate device at port 0.
...
No driver found at port: 0 for device (class 01), skip
USB Removing HCD device
```

### Build verification

- DJGPP DEBUG build (`make DEBUG=1`) compiles clean with the project's existing `-Werror -Wconversion -Wsign-compare -pedantic-errors` flags.
- DJGPP release build (`make`) also compiles clean — the assertion-only locals are correctly gated behind `#if DEBUG` so NDEBUG doesn't trigger `-Werror=unused-variable`.

### Regression verification

- `usb-kbd` (HID class 0x03 boot keyboard) on OHCI: binds correctly, no regression.
- The fix is additive — no allocations that previously succeeded should now fail. NCPB's retry budget (64 iterations in NDEBUG, unbounded with `extra +=` in DEBUG) is unchanged.

## References

- OHCI 1.0a Specification §§ 4.2.2, 4.3.1 — Endpoint Descriptor and Transfer Descriptor alignment and contiguity requirements.
- OHCI 1.0a Specification § 3.1.1.1 — Buffer page-crossing rules (the *only* DMA structure that supports a page crossing).
- EHCI bring-up macro pattern in `USBDDOS/HCD/ehci.c:25-30` — the proven precedent this PR applies to OHCI.
- DJGPP DPMI Memory FAQ — `mspace_malloc` returns C-pointer values; linear address requires `DS_BASE + offset` translation. Under HDPMI32 specifically, the DS base is *not* guaranteed to be page-aligned.
- DPMI 1.0 Specification § INT 31h/0504h — Physical-to-linear mapping semantics.

## Notes

- The defense-in-depth assertion at the HCCA register-write site is the actual debugging signal that surfaced the NCPB bug. Worth keeping as a regression guard — even if NCPB were to ever regress, this assertion will catch it before the controller silently corrupts DMA.
- The fix to `dpmi_bc.cpp`'s parallel implementation of `DPMI_DMAMallocNCPB` is **not** included in this PR — that file is for the Borland C build path which I haven't tested. The same fix applies analogously and could be a follow-up PR or a maintainer-side edit. The DJGPP and Watcom (`dpmi_wc.c`) builds are unaffected — Watcom doesn't expose `DPMI_DMAMallocNCPB` in the same way.
- Compilation under `-Werror=unused-variable`: the new defense-in-depth locals (`hccaStart`, `hccaEnd`, `hcdStart`, `hcdEnd`) are wrapped in `#if DEBUG` so they only exist in DEBUG builds, where they're actually consumed by `assert`. NDEBUG strips them entirely.
