### PR TITLE
EHCI: fix periodic schedule slot index for full-speed/low-speed bInterval

### DIFF
--- a/USBDDOS/HCD/ehci.c
+++ b/USBDDOS/HCD/ehci.c
@@ -558,7 +558,25 @@ void* EHCI_CreateEndpoint(HCD_Device* pDevice, uint8_t EPAddr, HCD_TxDir dir, ui
         if(EPS == EPS_HIGH)
             bInterval = (uint8_t)min(bInterval<=4?1:bInterval-4, EHCI_INTR_COUNT); //pack [1~4] to [1] and clamp [1~16] to [1~11]
         else
-            bInterval = min(bInterval, EHCI_INTR_COUNT);
+        {
+            /* USB 2.0 section 9.6.6: for full-speed and low-speed endpoints,
+             * bInterval is a LINEAR polling period in milliseconds (range
+             * 1..255), NOT a log-scale exponent the way it is for high-speed
+             * endpoints.  The EHCI periodic schedule's InterruptTail[] is
+             * indexed by log2 of the polling interval (slot i polls at 2^i
+             * frames = 2^i ms on EHCI).  Treating the linear millisecond
+             * value as a log-scale index put a typical 10ms HID keyboard
+             * into slot 7 (128ms polling, ~12.8x slower than requested).
+             *
+             * Convert linear ms to floor(log2) + 1 so the device lands on
+             * the largest slot whose polling interval is <= the requested
+             * bInterval.  bInterval=10 -> slot 3 (8ms); bInterval=8 -> slot 3
+             * (8ms); bInterval=255 -> clamped to slot 7 (128ms). */
+            uint8_t log2_floor = 0;
+            uint8_t v = bInterval;
+            while(v > 1U) { v >>= 1; log2_floor++; }
+            bInterval = (uint8_t)min((uint8_t)(log2_floor + 1U), (uint8_t)EHCI_INTR_COUNT);
+        }
         pQH->EXT.Interval = bInterval&0xFU;
         //EHCI_QH* head = &pHCData->InterruptQH[bInterval-1];
         EHCI_QH** tail = &pHCData->InterruptTail[bInterval-1];
@@ -593,7 +611,7 @@ BOOL EHCI_RemoveEndpoint(HCD_Device* pDevice, void* pEndpoint)
         result = EHCI_DetachQH(pQH, &pHCData->BulkQH, &pHCData->BulkTail);
     else if(bTransferType == USB_ENDPOINT_TRANSFER_TYPE_INTR || bTransferType == USB_ENDPOINT_TRANSFER_TYPE_ISOC)
     {
-        assert(pQH->EXT.Interval <= 11);
+        assert(pQH->EXT.Interval >= 1 && pQH->EXT.Interval <= EHCI_INTR_COUNT);
         EHCI_QH* head = &pHCData->InterruptQH[pQH->EXT.Interval-1];
         EHCI_QH** tail = &pHCData->InterruptTail[pQH->EXT.Interval-1];
         result = EHCI_DetachQH(pQH, head, tail);


### PR DESCRIPTION
# EHCI: fix periodic schedule slot index for full-speed/low-speed bInterval

## Summary

`EHCI_CreateEndpoint` placed full-speed and low-speed periodic endpoints on the wrong periodic-schedule slot. The full-speed/low-speed branch treated the device-reported `bInterval` (which is a linear millisecond period per USB 2.0 § 9.6.6) as if it were a log-scale exponent — the same way the high-speed branch correctly does for high-speed endpoints. A typical HID keyboard with `bInterval=10` (10 ms requested) was placed on slot 7, which polls at 128 ms — a 12.8× under-sampling.

The fix computes `floor(log2(bInterval)) + 1` and uses that (clamped to `EHCI_INTR_COUNT`) as the slot, which is the conventional closest-power-of-2-not-exceeding placement on EHCI periodic schedules.

Also tightens a stale assertion at the matching detach path.

Diff is +22 / -2 lines, `USBDDOS/HCD/ehci.c` only. No new dependencies, no header changes, no build-system changes.

## Motivation

Per USB 2.0 § 9.6.6 (Endpoint Descriptors), `bInterval` semantics depend on endpoint speed:

| Speed | `bInterval` semantics |
| --- | --- |
| Low-speed | Linear period in **frames (= milliseconds)**, range 10–255 for interrupt endpoints |
| Full-speed | Linear period in **frames (= milliseconds)**, range 1–255 for interrupt endpoints, 1–16 for isochronous |
| High-speed | **Log-scale exponent** — actual polling = `2^(bInterval-1)` microframes, range 1–16 |

EHCI's periodic schedule (per EHCI 1.0 § 4.2) is itself organized log-scale: a QH placed at frame-list entries at intervals of `2^i` is polled every `2^i` frames. USBDDOS's `InterruptTail[i]` is indexed by this log-scale slot.

The high-speed code path in `EHCI_CreateEndpoint` correctly converts the high-speed exponent to a frame-exponent. The full-speed/low-speed path did not — it just clamped the linear millisecond value and used it as a direct slot index:

```c
else
    bInterval = min(bInterval, EHCI_INTR_COUNT);
pQH->EXT.Interval = bInterval&0xFU;
EHCI_QH** tail = &pHCData->InterruptTail[bInterval-1];
```

For a full-speed HID keyboard reporting `bInterval=10` and `EHCI_INTR_COUNT=8`:

- `min(10, 8) = 8` → `InterruptTail[7]` → slot 7 polls at `2^7 = 128` frames = 128 ms

For other typical full-speed bInterval values, the same misindexing skews them all toward the slowest available slot:

| Device requests | Pre-patch slot | Pre-patch polling |
| --- | --- | --- |
| `bInterval=1` (1ms) | 0   | 1ms ✓ |
| `bInterval=2` (2ms) | 1   | 2ms ✓ |
| `bInterval=8` (8ms) | 7   | 128ms ❌ |
| `bInterval=10` (10ms) | 7 (clamped) | 128ms ❌ |
| `bInterval=64` (64ms) | 7 (clamped) | 128ms ❌ |
| `bInterval=255` (255ms) | 7 (clamped) | 128ms ✓ |

The values `bInterval=1` and `bInterval=2` happen to land on plausible slots only because 1 and 2 are exactly powers of 2 less than `EHCI_INTR_COUNT`. Every other typical HID/audio/printer bInterval (8, 10, 16, 32, 50, 100) gets the same 128 ms polling rate. Keys aren't necessarily silent in absolute terms, but the device is dramatically under-sampled.

## The fix

```c
else
{
    /* USB 2.0 9.6.6: FS/LS bInterval is a linear ms period, not a
     * log-scale exponent.  Convert to floor(log2)+1 for slot index. */
    uint8_t log2_floor = 0;
    uint8_t v = bInterval;
    while(v > 1U) { v >>= 1; log2_floor++; }
    bInterval = (uint8_t)min((uint8_t)(log2_floor + 1U), (uint8_t)EHCI_INTR_COUNT);
}
```

`bInterval=0` was already coerced to 1 at function entry by `bInterval = max(bInterval, 1)`, so the loop's initial `v=bInterval ≥ 1`, `log2_floor` stays 0 in that edge case, and the QH lands on slot 0 (fastest polling) — safe default.

Post-patch slot placements:

| Device requests | Post-patch slot | Post-patch polling |
| --- | --- | --- |
| `bInterval=1` (1ms) | 0   | 1ms ✓ |
| `bInterval=2` (2ms) | 1   | 2ms ✓ |
| `bInterval=8` (8ms) | 3   | 8ms ✓ |
| `bInterval=10` (10ms) | 3   | 8ms ✓ (closest power-of-2 ≤ 10) |
| `bInterval=64` (64ms) | 6   | 64ms ✓ |
| `bInterval=255` (255ms) | 7 (clamped) | 128ms ✓ (closest available ≤ 255) |

Conventional closest-power-of-2-not-exceeding placement, which is how EHCI scheduler implementations elsewhere (Linux `ehci-sched.c`, FreeBSD `ehci.c`) handle non-power-of-2 interrupt intervals on EHCI.

## High-speed handling is unchanged

The high-speed branch already does its own conversion:

```c
if(EPS == EPS_HIGH)
    bInterval = (uint8_t)min(bInterval<=4?1:bInterval-4, EHCI_INTR_COUNT);
```

This converts the high-speed microframe-exponent to a frame-exponent. There's a separate minor quirk in the `bInterval-4` arithmetic — strictly per USB 2.0 spec, high-speed `bInterval=N` means polling at `2^(N-1)` microframes = `2^(N-1)/8 = 2^(N-4)` frames, so the slot index should be `N-4` and the stored bInterval value should be `N-3`. The current code stores `N-4`, which is a consistent ~2× over-polling vs the device's request. That's harmless (extra bandwidth, no functional issue) and out of scope for this PR; can be addressed separately if desired.

## Adjacent cleanup

The detach path's assertion `assert(pQH->EXT.Interval <= 11)` at `EHCI_RemoveEndpoint`'s INTR/ISOC branch is updated to `assert(pQH->EXT.Interval >= 1 && pQH->EXT.Interval <= EHCI_INTR_COUNT)`. The `<= 11` value was correct when `EHCI_INTR_COUNT` was 11 in an earlier version of the code; it became stale (always-true) when the count was reduced to 8.

## Testing

- DJGPP release (NDEBUG) and DEBUG builds compile clean with the project's full `-Werror -Wconversion -Wsign-compare -pedantic-errors` flag set.
- Open Watcom v2 release and DEBUG builds compile clean. The only warning is a pre-existing `W201: Unreachable code` in `dbgutil.c:163` unrelated to this PR.
- QEMU OHCI + `usb-kbd` enumeration smoke test: HID class 3 endpoint created, `Set boot protocol`, `Set idle`, `start driver` — no regression on the unaffected OHCI path.
- QEMU EHCI + `usb-kbd` enumeration smoke test: same — no regression on the EHCI path either.
- Worked-example math verified for `bInterval ∈ {0, 1, 2, 4, 8, 10, 16, 32, 64, 100, 128, 200, 255}`.

## References

- USB 2.0 spec § 9.6.6 — Endpoint Descriptors (bInterval semantics by speed)
- EHCI 1.0 spec § 4.2 — Periodic Schedule
- Linux `drivers/usb/host/ehci-sched.c` — reference implementation for closest-power-of-2 interrupt-endpoint placement on EHCI
- FreeBSD `sys/dev/usb/controller/ehci.c` — same pattern

## Notes

- The log2 computation is an integer loop (no `__builtin_clz`, no floating-point) — portable across DJGPP gcc, Open Watcom wcc, and Borland C++.
- Single-file change. No header changes, no build system changes, no API changes.
- This PR is independent of the fork-side investigation that surfaced the bug (an HID-via-EHCI-high-speed-hub issue still under diagnosis). The H5 fix is correct on its own regardless of how that investigation resolves.