### PR TITLE
OOM hardening: DMAMalloc returns NULL cleanly, callsites check

### DIFF
--- a/USBDDOS/CLASS/hub.c
+++ b/USBDDOS/CLASS/hub.c
@@ -162,6 +162,11 @@ BOOL USB_HUB_InitDevice(USB_Device* pDevice)
     USB_HubDesc desc;
     USB_Request req = {USB_REQ_READ|USB_REQ_TYPE_HUB, USB_REQ_GET_DESCRIPTOR, USB_DT_HUB<<8, 0, sizeof(desc)};
     void* dma = DPMI_DMAMalloc(sizeof(desc), 4);
+    if(!dma) /* F-AUDIT-1 */
+    {
+        _LOG("HUB: failed to alloc DMA buffer (%u bytes)\n", (unsigned)sizeof(desc));
+        return FALSE;
+    }
     uint8_t err = USB_SyncSendRequest(pDevice, &req, dma);
     memcpy(&desc, dma, sizeof(desc));
     if(err != 0)

--- a/USBDDOS/DPMI/dpmi_bc.cpp
+++ b/USBDDOS/DPMI/dpmi_bc.cpp
@@ -972,8 +972,13 @@ void* DPMI_DMAMalloc(unsigned int size, unsigned int alignment)
 {
     CLIS();
     alignment = max(alignment,4);
-    uint8_t* ptr = (uint8_t*)malloc(size + alignment + 2) + 2;
-    assert((short)ptr != 2);
+    /* F-AUDIT-1: check malloc return before pointer arithmetic.
+     * Old code did `malloc(...) + 2` producing 0x00000002 on OOM, which
+     * downstream callers couldn't distinguish from a valid pointer.
+     */
+    uint8_t* raw = (uint8_t*)malloc(size + alignment + 2);
+    if(raw == NULL) { STIL(); return NULL; }
+    uint8_t* ptr = raw + 2;
     uint32_t addr = DPMI_PTR2L(ptr);
     uint16_t offset = (uint16_t)(align(addr, alignment) - addr);
     void* aligned = ptr + offset;

--- a/USBDDOS/DPMI/dpmi_dj2.c
+++ b/USBDDOS/DPMI/dpmi_dj2.c
@@ -287,8 +287,11 @@ void* DPMI_DMAMalloc(unsigned int size, unsigned int alignment/* = 4*/)
 {
     #if DEBUG
     CLIS();
+    /* F-AUDIT-1: check mspace_malloc return before pointer arithmetic. */
+    uint8_t* raw = (uint8_t*)mspace_malloc(XMS_Space, size+alignment+8);
+    if(raw == NULL) { STIL(); return NULL; }
     XMS_Allocated += size;
-    uint8_t* ptr = (uint8_t*)mspace_malloc(XMS_Space, size+alignment+8) + 8;
+    uint8_t* ptr = raw + 8;
     uintptr_t addr = (uintptr_t)ptr;
     uint32_t offset = align(addr, alignment) - addr;
     uint32_t* uptr = (uint32_t*)(ptr + offset);

--- a/USBDDOS/HCD/ehci.c
+++ b/USBDDOS/HCD/ehci.c
@@ -113,6 +113,11 @@ BOOL EHCI_InitController(HCD_Interface * pHCI, PCI_DEVICE* pPCIDev)
     }
 
     pHCI->pHCDData = DPMI_DMAMalloc(sizeof(EHCI_HCData), EHCI_ALIGN);
+    if(!pHCI->pHCDData) /* F-AUDIT-1 */
+    {
+        _LOG("EHCI: failed to alloc HCData (%u bytes)\n", (unsigned)sizeof(EHCI_HCData));
+        return FALSE;
+    }
     EHCI_HCData* pHCData = (EHCI_HCData*)pHCI->pHCDData;
     memset(pHCData, 0, sizeof(EHCI_HCData));
 
@@ -475,6 +480,11 @@ BOOL EHCI_SetPortStatus(HCD_Interface* pHCI, uint8_t port, uint16_t status)
 BOOL EHCI_InitDevice(HCD_Device* pDevice)
 {
     pDevice->pHCData = DPMI_DMAMalloc(sizeof(EHCI_HCDeviceData), EHCI_ALIGN);
+    if(!pDevice->pHCData) /* F-AUDIT-1 */
+    {
+        _LOG("EHCI: failed to alloc per-device HCData (%u bytes)\n", (unsigned)sizeof(EHCI_HCDeviceData));
+        return FALSE;
+    }
     EHCI_HCDeviceData* pDeviceData = (EHCI_HCDeviceData*)pDevice->pHCData;
     memset(pDeviceData, 0, sizeof(EHCI_HCDeviceData));
     //EHCI_HCData* pHCData = (EHCI_HCData*)pDevice->pHCI->pHCDData;
@@ -647,7 +657,11 @@ BOOL EHCI_SetupPeriodicList(HCD_Interface* pHCI)
 
     // build frame list entries
     EHCI_FLEP* flep = (EHCI_FLEP*)malloc(4096);
-    assert(flep);
+    if(!flep) /* F-AUDIT-1 */
+    {
+        _LOG("EHCI: failed to malloc 4096 for frame list\n");
+        return FALSE;
+    }
     {//scope for BC
         for(int i = 0; i < 1024; ++i)
             flep[i].Ptr = (Typ_QH<<Typ_Shift) | Tbit;

--- a/USBDDOS/HCD/ohci.c
+++ b/USBDDOS/HCD/ohci.c
@@ -184,6 +184,11 @@ BOOL OHCI_InitController(HCD_Interface* pHCI, PCI_DEVICE* pPCIDev)
 
     pHCI->pHCDMethod = &OHCI_Method;
     pHCI->pHCDData = DPMI_DMAMalloc(sizeof(OHCI_HCData), 256);
+    if(!pHCI->pHCDData) /* F-AUDIT-1 */
+    {
+        _LOG("OHCI: failed to alloc HCData (%u bytes)\n", (unsigned)sizeof(OHCI_HCData));
+        return FALSE;
+    }
     OHCI_HCData* pHCDData = (OHCI_HCData*)pHCI->pHCDData;
     memset(pHCDData, 0, sizeof(OHCI_HCData));
     _LOG("HCDDData %08x, Initial memory usage: %d\n", pHCDData, sizeof(OHCI_HCData));
@@ -762,6 +767,11 @@ BOOL OHCI_SetPortStatus(HCD_Interface* pHCI, uint8_t port, uint16_t status)
 BOOL OHCI_InitDevice(HCD_Device* pDevice)
 {
     pDevice->pHCData = DPMI_DMAMalloc(sizeof(OHCI_HCDeviceData), 16);
+    if(!pDevice->pHCData) /* F-AUDIT-1 */
+    {
+        _LOG("OHCI: failed to alloc per-device HCData (%u bytes)\n", (unsigned)sizeof(OHCI_HCDeviceData));
+        return FALSE;
+    }
     OHCI_HCDeviceData* pDD = (OHCI_HCDeviceData*)pDevice->pHCData;
     memset(pDD, 0, sizeof(OHCI_HCDeviceData));
     _LOG("Device %08x, memory usage: %d\n", pDD, sizeof(OHCI_HCDeviceData));

--- a/USBDDOS/HCD/uhci.c
+++ b/USBDDOS/HCD/uhci.c
@@ -106,6 +106,11 @@ BOOL UHCI_InitController(HCD_Interface * pHCI, PCI_DEVICE* pPCIDev)
     DataArea = DataArea < 0x100000L ? DataArea : DPMI_MapMemory(DataArea, 4096);    //1024 entry, 4 bytes per entry.
     _LOG("UHCI frame list base address: %08lx\n", DataArea);
     pHCI->pHCDData = DPMI_DMAMalloc(sizeof(UHCI_HCData), 16);
+    if(!pHCI->pHCDData) /* F-AUDIT-1 */
+    {
+        _LOG("UHCI: failed to alloc HCData (%u bytes)\n", (unsigned)sizeof(UHCI_HCData));
+        return FALSE;
+    }
     UHCI_HCData* pHCData = (UHCI_HCData*)pHCI->pHCDData;
     memset(pHCData, 0, sizeof(UHCI_HCData));
 
@@ -551,6 +556,11 @@ BOOL UHCI_SetPortStatus(HCD_Interface* pHCI, uint8_t port, uint16_t status)
 BOOL UHCI_InitDevice(HCD_Device* pDevice)
 {
     pDevice->pHCData = DPMI_DMAMalloc(sizeof(UHCI_HCDeviceData), 16);
+    if(!pDevice->pHCData) /* F-AUDIT-1 */
+    {
+        _LOG("UHCI: failed to alloc per-device HCData (%u bytes)\n", (unsigned)sizeof(UHCI_HCDeviceData));
+        return FALSE;
+    }
     UHCI_HCDeviceData* pDeviceData = (UHCI_HCDeviceData*)pDevice->pHCData;
     memset(pDeviceData, 0, sizeof(UHCI_HCDeviceData));
     

--- a/USBDDOS/usb.c
+++ b/USBDDOS/usb.c
@@ -685,7 +685,12 @@ BOOL USB_ParseConfiguration(uint8_t* pBuffer, uint16_t length, USB_Device* pDevi
                 pDevice->pConfigList[ConfigIndex].bNumInterfaces = 32;
             }
             USB_InterfaceDesc* pInterfaceDesc = (USB_InterfaceDesc*)malloc(sizeof(USB_InterfaceDesc)*pDevice->pConfigList[ConfigIndex].bNumInterfaces);
-            assert(pInterfaceDesc);
+            if(!pInterfaceDesc) /* F-AUDIT-1 */
+            {
+                _LOG("USB: malloc failed for %u interfaces; bailing parse\n",
+                     pDevice->pConfigList[ConfigIndex].bNumInterfaces);
+                return FALSE;
+            }
             memset(pInterfaceDesc, 0, sizeof(USB_InterfaceDesc)*pDevice->pConfigList[ConfigIndex].bNumInterfaces);
             pDevice->pConfigList[ConfigIndex].pInterfaces = pInterfaceDesc;
         }
@@ -1045,7 +1050,14 @@ static void USB_ConfigEndpoints(USB_Device* pDevice)
             epd->bmAttributesBits.TransferType,
             epd->wMaxPacketSizeFlags.Size,
             epd->bInterval);    //create EP
-        assert(ep);
+        if(!ep) /* F-AUDIT-1: HCD endpoint allocation failed; skip this EP */
+        {
+            _LOG("USB: CreateEndpoint failed for class %x ep %02x [%u/%u]; skipping\n",
+                 pDevice->Desc.bDeviceClass, epd->bEndpointAddress, i+1, bNumEndpoints);
+            pDevice->pEndpoints[i] = NULL;
+            pDevice->pEndpointDesc[i] = epd;
+            continue;
+        }
         _LOG("Class %x Endpoint %02x created: %08x [%u/%u]\n", pDevice->Desc.bDeviceClass, epd->bEndpointAddress, ep, i+1, bNumEndpoints);
         pDevice->pEndpoints[i] = ep;
         pDevice->pEndpointDesc[i] = epd;


### PR DESCRIPTION
## What

`DPMI_DMAMalloc` can return `NULL` under memory pressure, but several callers
either performed offset arithmetic on the result or guarded it only with
`assert()`, which compiles out under `NDEBUG` (RELEASE builds). On a failed
allocation those paths dereferenced a near-NULL pointer instead of failing
cleanly.

## Fix

- `DPMI_DMAMalloc` hardened at the source so it no longer does offset arithmetic
  on a NULL `malloc` return.
- Ten call sites converted from `assert(p)` / unchecked dereference to a graceful
  `if (!p) { _LOG(...); return ...; }`.

## Files
- `USBDDOS/CLASS/hub.c`
- `USBDDOS/DPMI/dpmi_bc.cpp`
- `USBDDOS/DPMI/dpmi_dj2.c`
- `USBDDOS/HCD/ehci.c`
- `USBDDOS/HCD/ohci.c`
- `USBDDOS/HCD/uhci.c`
- `USBDDOS/usb.c`

No change on the success path; this only adds clean failure handling where an
allocation fails.
