### PR TITLE
usb: log USB device-capacity rejects to COM1

### DIFF
--- a/USBDDOS/usb.c
+++ b/USBDDOS/usb.c
@@ -279,9 +279,21 @@ BOOL USB_InitDevice(HCD_HUB* pHub, uint8_t portIndex, uint16_t portStatus)
 {
     //early return
     if(pHub->pHCI->bDevCount >= USB_MAX_HC_COUNT)
+    {
+        _LOG("USB: bDevCount >= USB_MAX_HC_COUNT (%d) on HC; refusing device on port %d\n",
+             USB_MAX_HC_COUNT, portIndex);
         return FALSE;
+    }
     if(USBT.DeviceCount >= USB_MAX_DEVICE_COUNT)
+    {
+        /* F-AUDIT-2: silent reject was a real-world support nightmare.
+         * Make it visible in COM1 capture so users can identify the cause.
+         */
+        _LOG("USB: DeviceCount >= USB_MAX_DEVICE_COUNT (%d); refusing device on port %d. "
+             "Hint: bump USB_MAX_DEVICE_COUNT in usbcfg.h\n",
+             USB_MAX_DEVICE_COUNT, portIndex);
         return FALSE;
+    }
 
     USB_Device* pDevice = NULL;
     uint8_t address;


### PR DESCRIPTION
## What

When `USB_InitDevice` rejects a device because the host controller's or the
global device-table capacity is exhausted, it did so silently. In hub
configurations this made "some devices just don't show up" hard to diagnose.

## Fix

Emit a `_LOG` line identifying which limit was hit and on which port when a
capacity reject occurs.

## Files
- `USBDDOS/usb.c`

## Notes / scope

This is the visibility half only. An earlier version of this change also raised
`USB_MAX_DEVICE_COUNT` from 4 to 8 on Watcom/Borland builds, but that was found to
hang RELEASE-Watcom on the no-device tests (any increase above 4 triggers a silent
hang in the `usb.c` init flow), so the count bump is deferred to a separate
investigation pending root-cause analysis. RELEASE binaries are byte-identical to
stock here; the new strings appear only in DEBUG builds.
