### PR TITLE
Bounded control-transfer wait + UHCI abort (fixes enumeration hang on NAK-forever devices)

### DIFF
--- a/USBDDOS/HCD/ehci.c
+++ b/USBDDOS/HCD/ehci.c
@@ -48,6 +48,7 @@ HCD_Method EHCI_AccessMethod =
     &EHCI_RemoveDevice,
     &EHCI_CreateEndpoint,
     &EHCI_RemoveEndpoint,
+    NULL, //AbortControl: not yet implemented for EHCI (timeout falls back to wait)
 };
 
 static void EHCI_ResetHC(HCD_Interface* pHCI);

--- a/USBDDOS/HCD/hcd.c
+++ b/USBDDOS/HCD/hcd.c
@@ -182,3 +182,28 @@ BOOL HCD_InvokeCallBack(HCD_Request* pRequest, uint16_t actuallen, uint8_t ecode
     USB_TFree32(req);
     return TRUE;
 }
+
+void HCD_AbortRequests(HCD_Device* pDevice, void* pEndpoint)
+{
+    if(pDevice == NULL)
+        return;
+    CLIS();
+    HCD_Request* req = pDevice->pRequest;
+    HCD_Request* prev = NULL;
+    while(req != NULL)
+    {
+        HCD_Request* next = req->pNext;
+        if(req->pEndpoint == pEndpoint)
+        {
+            if(prev)
+                prev->pNext = next;
+            else
+                pDevice->pRequest = next;
+            USB_TFree32(req); //no callback: the freed TDs no longer reference it
+        }
+        else
+            prev = req;
+        req = next;
+    }
+    STIL();
+}

--- a/USBDDOS/HCD/hcd.h
+++ b/USBDDOS/HCD/hcd.h
@@ -95,6 +95,12 @@ typedef struct HCD_HostrControllerDriverMethod
 
     BOOL (*RemoveEndPoint)(HCD_Device* pDevice, void* pEndpoint);
 
+    //Abort the in-flight control transfer on the default control pipe: stop the
+    //HC executing the QH, free the queued TDs, restore a clean tail, leaving the
+    //EP usable. Called by the control-transfer timeout. May be NULL (HC without
+    //abort support, in which case the timeout falls back to waiting).
+    BOOL (*AbortControl)(HCD_Device* pDevice, void* pEndpoint);
+
 }HCD_Method;
 
 typedef struct HCD_HostControllerType
@@ -137,6 +143,11 @@ HCD_Request* HCD_AddRequest(HCD_Device* pDevice, void* pEndpoint, HCD_TxDir dir,
 
 //invoke callback and remove the request entry
 BOOL HCD_InvokeCallBack(HCD_Request* pRequest, uint16_t actuallen, uint8_t ecode);
+
+//Drop any in-flight requests for an endpoint without invoking their callbacks.
+//Used by the control-transfer timeout after the HC has freed the stuck TDs, so
+//no TD still references these requests.
+void HCD_AbortRequests(HCD_Device* pDevice, void* pEndpoint);
 
 //the initial state of all ports on a hub device should be disabled, @see USB_EnumerateDevices
 typedef struct HCD_HUB

--- a/USBDDOS/HCD/ohci.c
+++ b/USBDDOS/HCD/ohci.c
@@ -91,6 +91,7 @@ HCD_Method OHCI_Method =
     &OHCI_RemoveDevice,
     &OHCI_CreateEndpoint,
     &OHCI_RemoveEndpoint,
+    NULL, //AbortControl: not yet implemented for OHCI (timeout falls back to wait)
 };
 
 BOOL OHCI_InitController(HCD_Interface* pHCI, PCI_DEVICE* pPCIDev)

--- a/USBDDOS/HCD/uhci.c
+++ b/USBDDOS/HCD/uhci.c
@@ -26,6 +26,7 @@ static BOOL UHCI_InitDevice(HCD_Device* pDevice);
 static BOOL UHCI_RemoveDevice(HCD_Device* pDevice);
 static void* UHCI_CreateEndpoint(HCD_Device* pDevice, uint8_t EPAddr, HCD_TxDir dir, uint8_t bTransferType, uint16_t MaxPacketSize, uint8_t bInterval);
 static BOOL UHCI_RemoveEndpoint(HCD_Device* pDevice, void* pEndpoint);
+static BOOL UHCI_AbortControl(HCD_Device* pDevice, void* pEndpoint);
 
 static void UHCI_EnableInterrupt(HCD_Interface* pHCI, BOOL enable);
 static void UHCI_QHTDSchedule(HCD_Interface* pHCI);
@@ -54,6 +55,7 @@ HCD_Method UHCIAccessMethod =
     &UHCI_RemoveDevice,
     &UHCI_CreateEndpoint,
     &UHCI_RemoveEndpoint,
+    &UHCI_AbortControl,
 };
 
 BOOL UHCI_InitController(HCD_Interface * pHCI, PCI_DEVICE* pPCIDev)
@@ -684,6 +686,39 @@ BOOL UHCI_RemoveEndpoint(HCD_Device* pDevice, void* pEndpoint)
     //UHCI_StartHC(pDevice->pHCI);
     UHCI_EnableInterrupt(pDevice->pHCI, TRUE);
     return result;
+}
+
+//Abort the in-flight control transfer without tearing down the (persistent)
+//default-control QH: point its element link at the terminate flag so the HC
+//stops executing the queued chain, free that chain, restore a fresh empty tail,
+//and clear the data toggle. Pairs with the control-transfer timeout in
+//USB_SyncSendRequest + HCD_AbortRequests (which drops the pending request).
+BOOL UHCI_AbortControl(HCD_Device* pDevice, void* pEndpoint)
+{
+    UHCI_QH* pQH = UHCI_ED_GETQH(pEndpoint);
+    if(pDevice == NULL || pQH == NULL)
+        return FALSE;
+    UHCI_EnableInterrupt(pDevice->pHCI, FALSE);
+    CLIS();
+    pQH->ElementLink = TerminateFlag;       //HC stops executing the queued TDs
+    UHCI_TD* pTD = pQH->pTail;              //free the whole queued chain
+    while(pTD != NULL)
+    {
+        UHCI_TD* pPrev = pTD->pPrev;
+        USB_TFree32(pTD);
+        pTD = pPrev;
+    }
+    pQH->pTail = NULL;
+    UHCI_TD* pNew = (UHCI_TD*)USB_TAlloc32(sizeof(UHCI_TD)); //fresh empty tail
+    if(pNew != NULL)
+    {
+        memset(pNew, 0, sizeof(UHCI_TD));
+        UHCI_InsertTDintoQH(pQH, pNew);
+    }
+    pQH->Flags.DataToggle = 0;              //clean toggle for the next transfer
+    STIL();
+    UHCI_EnableInterrupt(pDevice->pHCI, TRUE);
+    return TRUE;
 }
 
 void UHCI_EnableInterrupt(HCD_Interface* pHCI, BOOL enable)

--- a/USBDDOS/usb.c
+++ b/USBDDOS/usb.c
@@ -479,6 +479,23 @@ uint8_t USB_SendRequest(USB_Device* pDevice, USB_Request* pRequest, void* pBuffe
     return pFn(&pDevice->HCDDevice, pDevice->pDefaultControlEP, dir, request, dma, pRequest->wLength, USB_Completion_UserCallback, pUserData);
 }
 
+#ifndef USB_CONTROL_TIMEOUT_MS
+#define USB_CONTROL_TIMEOUT_MS 2000     /* cap on a single control transfer */
+#endif
+#define USB_ERROR_TIMEOUT      0xFEu    /* synthetic error for a timed-out transfer */
+
+/* PIT channel-0 current count: decrements at ~1.193182 MHz, wraps every ~54.9ms.
+ * A latched read is atomic and IRQ-mask independent, so it advances even inside
+ * the control-transfer wait, which masks the timer IRQ and freezes the BIOS tick. */
+static uint16_t USB_PITCount(void)
+{
+    uint16_t lo, hi;
+    outp(0x43, 0x00);   /* latch counter 0 */
+    lo = inp(0x40);
+    hi = inp(0x40);
+    return (uint16_t)((hi << 8) | lo);
+}
+
 uint8_t USB_SyncSendRequest(USB_Device* pDevice, USB_Request* pRequest, void* pBuffer)
 {
     USB_SyncCallbackResult result;
@@ -497,8 +514,60 @@ uint8_t USB_SyncSendRequest(USB_Device* pDevice, USB_Request* pRequest, void* pB
     STIL();
 #endif
 
-    while(!result.Finished)
-        USB_IDLE_WAIT();
+    {
+        /* Bounded control wait. The HC completion callback sets result.Finished;
+         * a device that NAKs the data stage forever never completes the TD, so
+         * cap the wait (PIT-timed -- works in this IRQ-masked region where the
+         * BIOS tick is frozen) and abort the stuck transfer instead of hanging. */
+        uint32_t elapsed = 0;
+        uint16_t prev = USB_PITCount();
+        const uint32_t limit = (uint32_t)USB_CONTROL_TIMEOUT_MS * 1193UL; /* counts */
+        BOOL timedout = FALSE;
+        while(!result.Finished)
+        {
+            USB_IDLE_WAIT();
+            uint16_t now = USB_PITCount();
+            elapsed += (uint16_t)(prev - now); /* counts down; u16 wrap-safe */
+            prev = now;
+            if(elapsed >= limit) { timedout = TRUE; break; }
+        }
+        if(timedout && !result.Finished)
+        {
+            HCD_Interface* pHCI = pDevice->HCDDevice.pHCI;
+#if DEBUG
+            _LOG("CONTROL TIMEOUT(%dms) a%d bmReq=%02x bReq=%02x wVal=%04x wIdx=%04x wLen=%d base=%08lx irq=%d port=%d\n",
+                USB_CONTROL_TIMEOUT_MS, pDevice->HCDDevice.bAddress, pRequest->bmRequestType, pRequest->bRequest,
+                pRequest->wValue, pRequest->wIndex, pRequest->wLength,
+                (unsigned long)pHCI->dwBaseAddress, pHCI->PCI.Header.DevHeader.Device.IRQ, pDevice->HCDDevice.bHubPort);
+            if(pHCI->dwBaseAddress < 0x10000UL)
+            {
+                uint16_t b = (uint16_t)pHCI->dwBaseAddress;
+                _LOG("  UHCI USBCMD=%04x USBSTS=%04x FRNUM=%04x PORTSC%d=%04x\n",
+                    inpw((uint16_t)(b+0)), inpw((uint16_t)(b+2)), inpw((uint16_t)(b+6)),
+                    pDevice->HCDDevice.bHubPort,
+                    inpw((uint16_t)(b + 0x10 + pDevice->HCDDevice.bHubPort*2)));
+            }
+#endif
+            if(pHCI->pHCDMethod->AbortControl != NULL)
+            {
+                /* Free the stuck TDs first (so no TD still references the request),
+                 * then drop the in-flight request so its callback can never fire
+                 * into this stack frame. Order matters. */
+                pHCI->pHCDMethod->AbortControl(&pDevice->HCDDevice, pDevice->pDefaultControlEP);
+                HCD_AbortRequests(&pDevice->HCDDevice, pDevice->pDefaultControlEP);
+                result.ErrorCode = USB_ERROR_TIMEOUT;
+                result.Finished = TRUE;
+            }
+            else
+            {
+                /* HC without abort support: can't safely abandon the wait (the
+                 * callback still points at &result), so fall back to waiting. */
+                _LOG("CONTROL timeout; no abort for this HC, waiting\n");
+                while(!result.Finished)
+                    USB_IDLE_WAIT();
+            }
+        }
+    }
 
 #if USB_MASK_IRQ_ON_IDLEWAIT
     {


### PR DESCRIPTION
## Problem

`USB_SyncSendRequest` waits unboundedly for a control transfer to complete.
A device that NAKs forever (common on dock/hub topologies with
vendor-specific or half-alive functions) hangs enumeration — and with it
the whole boot — on the first string-descriptor request it never answers.

## Change

- Bound the control-transfer wait (2000 ms, PIT-based) and, on expiry, log
  one line with the request and controller state
  (`USBCMD/USBSTS/FRNUM/PORTSC`) to the debug console.
- Add an optional `AbortControl` method to the HCD vtable: stop the HC
  executing the default pipe's QH, free the queued TDs, restore a clean
  tail, leaving EP0 usable for the next request. Implemented for UHCI;
  EHCI/OHCI pass `NULL` for now, in which case the timeout simply gives up
  on that request and enumeration continues.

## Field validation

Tested on an IBM 300GL (PIIX UHCI) with a docking station whose internal
hub hosts devices that never answer string requests: seven timeouts in one
boot, each aborted cleanly; enumeration completed; a 4.5 MB copy from a
mass-storage device behind the same hub succeeded afterwards. Full serial
captures in netrunner01#2.

Builds clean with Open Watcom and DJGPP. No behavior change for devices
that respond normally.
