### PR TITLE
Device pool: bounds-guard the free-slot scan, raise 16-bit pool 4->8, correct wrong-constant guard

### DIFF
--- a/USBDDOS/usb.c
+++ b/USBDDOS/usb.c
@@ -278,20 +278,10 @@ BOOL USB_InitController(uint8_t bus, uint8_t dev, uint8_t func, PCI_DEVICE* pPCI
 BOOL USB_InitDevice(HCD_HUB* pHub, uint8_t portIndex, uint16_t portStatus)
 {
     //early return
-    if(pHub->pHCI->bDevCount >= USB_MAX_HC_COUNT)
+    if(pHub->pHCI->bDevCount >= HCD_MAX_DEVICE_COUNT)
     {
-        _LOG("USB: bDevCount >= USB_MAX_HC_COUNT (%d) on HC; refusing device on port %d\n",
-             USB_MAX_HC_COUNT, portIndex);
-        return FALSE;
-    }
-    if(USBT.DeviceCount >= USB_MAX_DEVICE_COUNT)
-    {
-        /* F-AUDIT-2: silent reject was a real-world support nightmare.
-         * Make it visible in COM1 capture so users can identify the cause.
-         */
-        _LOG("USB: DeviceCount >= USB_MAX_DEVICE_COUNT (%d); refusing device on port %d. "
-             "Hint: bump USB_MAX_DEVICE_COUNT in usbcfg.h\n",
-             USB_MAX_DEVICE_COUNT, portIndex);
+        _LOG("USB: HC device limit reached (%d); refusing device on port %d\n",
+             HCD_MAX_DEVICE_COUNT, portIndex);
         return FALSE;
     }
 
@@ -301,6 +291,12 @@ BOOL USB_InitDevice(HCD_HUB* pHub, uint8_t portIndex, uint16_t portStatus)
     {
         if(!HCD_IS_DEVICE_VALID(&USBT.Devices[address].HCDDevice))
             break;
+    }
+    if(address >= USB_MAX_DEVICE_COUNT)
+    {   //pool full: refuse the device rather than index past Devices[]
+        _LOG("USB device pool full (%d): device at port %d not enumerated. "
+             "Hint: bump USB_MAX_DEVICE_COUNT in usbcfg.h\n", USB_MAX_DEVICE_COUNT, portIndex);
+        return FALSE;
     }
     pDevice = &USBT.Devices[address];
     address = (uint8_t)(address + 1); //1 based

--- a/USBDDOS/usb.h
+++ b/USBDDOS/usb.h
@@ -270,7 +270,6 @@ typedef struct
     USB_Routine InitFunctions[USB_MAX_DEVICE_COUNT]; //un-ordered function array
     uint16_t HC_Count;
     volatile uint16_t HUB_Count; //hub count changes during enumeration, i.e. new hub device found
-    uint16_t DeviceCount;
 }USB_Table;
 
 extern USB_Table USBT;

--- a/USBDDOS/usbcfg.h
+++ b/USBDDOS/usbcfg.h
@@ -11,7 +11,7 @@
 //constants
 #define HCD_MAX_DEVICE_COUNT 15     //device per root hub by spec
 #if defined(__BC__) || defined(__WC__)
-#define USB_MAX_DEVICE_COUNT 4      //save 16 bit memory
+#define USB_MAX_DEVICE_COUNT 8      //small pool to save 16-bit real-mode memory (~144 bytes/slot)
 #else
 #define USB_MAX_DEVICE_COUNT 127    //no need to change, max address 127
 #endif


### PR DESCRIPTION
## Problem

The free-slot scan in `USB_InitDevice` has no bounds check:

```c
for(address = 0; ; ++address)
    if(!HCD_IS_DEVICE_VALID(&USBT.Devices[address].HCDDevice)) break;
```

With every slot valid, `address` walks one element past `Devices[]` and
the subsequent `memset` corrupts whatever follows the array (in the
16-bit build, a function-pointer table), crashing with a GP fault the
moment a 5th concurrent device appears — which a docking station's
cascaded hubs reach easily.

The existing early-return guards don't prevent this: one compares against
`USB_MAX_HC_COUNT` (wrong constant), the other tests `USBT.DeviceCount`,
which nothing ever increments, so it can never fire.

## Change

- Bounds-guard the scan: a full pool refuses the device with a log line
  (the "bump `USB_MAX_DEVICE_COUNT`" hint from the recent visibility work
  is folded into this live message) instead of corrupting memory.
- Correct the early-return guard to `HCD_MAX_DEVICE_COUNT`, keeping its
  log line.
- Remove the `DeviceCount` field and its dead guard.
- Raise `USB_MAX_DEVICE_COUNT` from 4 to 8 for the 16-bit build (~576
  bytes of resident growth, measured) so dock topologies fit: root hub
  devices + external hub + its children exceed 4 trivially.

## Field validation

IBM 300GL with docking station (netrunner01#2): the 5th-device point was
reached twice in one boot — both enumerated, found unclaimed, and removed
cleanly; previously this was a hard crash at the same point. A 4.5 MB
copy from a dock-attached drive succeeded in the same run.

Builds clean with Open Watcom and DJGPP.
