### PR TITLE
DPMI: defer nested hardware IRQs to avoid reentering the non-reentrant V86 mode switch (fixes GP fault)

### DIFF
--- a/USBDDOS/DPMI/dpmi_bc.h
+++ b/USBDDOS/DPMI/dpmi_bc.h
@@ -1718,6 +1718,18 @@ DPMI_DEFAULT_CLIENT_IRQ(15)
 #pragma enable_message (13) //WC: unreachable code, but seems invalid
 #pragma option -k //BC
 
+//A reflected hardware IRQ may require a mode-switch round-trip (PM<->V86 via
+//VCPI, or the RMCB) to reach its real-mode handler. That round-trip uses a
+//single client-state save area and is NOT reentrant: if a second hardware
+//IRQ is taken (at the PM IDT) while the first is still mid-round-trip, the
+//nested switch clobbers the outer saved frame and the outer context resumes
+//in the wrong CPU mode (e.g. a V86 frame resumed as protected mode), faulting
+//in unrelated code. Guard against this by deferring any hardware IRQ that
+//arrives while another is being serviced: mask it, EOI it so the PIC is not
+//left in-service, and re-deliver it (the source device keeps its data latched,
+//so the line re-asserts on unmask) once the outer service completes.
+static uint8_t DPMI_HWIRQInService = 0;
+static uint16_t DPMI_HWIRQDeferred = 0;
 
 extern "C" void __CDECL near DPMI_HWIRQHandlerInternal()
 {
@@ -1725,7 +1737,15 @@ extern "C" void __CDECL near DPMI_HWIRQHandlerInternal()
     if(irq == 0xFF) //already handled (shared IRQ handled by other driver)
         return;
 
-    //_LOG("HWIRQ %d\n", irq);
+    if(DPMI_HWIRQInService) //nested HW IRQ: defer rather than re-enter the non-reentrant mode switch
+    {
+        PIC_MaskIRQ(irq);
+        PIC_SendSpecificEOI(irq);
+        DPMI_HWIRQDeferred |= (uint16_t)(1<<irq);
+        return;
+    }
+    DPMI_HWIRQInService = 1;
+
     uint8_t vec = PIC_IRQ2VEC(irq);
     //assert(vec >= 0x08 && vec <= 0x0F || vec >= 0x70 && vec <= 0x77);
     void (far* handler)(void) = DPMI_ClientINTHandler[vec]; //save on stack, we are going to modify ds
@@ -1755,6 +1775,19 @@ extern "C" void __CDECL near DPMI_HWIRQHandlerInternal()
     }
     else
         DPMI_Call_OldIVT(irq);
+
+    DPMI_HWIRQInService = 0;
+    //re-deliver any IRQs deferred during this service: unmask so the still-asserted
+    //device line re-fires, now in a non-nested context.
+    if(DPMI_HWIRQDeferred)
+    {
+        uint16_t pending = DPMI_HWIRQDeferred;
+        DPMI_HWIRQDeferred = 0;
+        for(uint8_t b = 0; b < 16; ++b)
+            if(pending & (1<<b))
+                PIC_UnmaskIRQ(b);
+    }
+
 }
 
 #pragma option -k- //BC

--- a/USBDDOS/pic.c
+++ b/USBDDOS/pic.c
@@ -33,6 +33,19 @@ void PIC_SendEOI(void)
     //STIL();
 }
 
+//Specific EOI for a single IRQ line, leaving any other in-service IRQ intact.
+//Needed when acknowledging one IRQ while another is still being serviced.
+void PIC_SendSpecificEOI(uint8_t irq)
+{
+    if(irq >= 8)
+    {
+        outp(PIC_PORT2, (uint8_t)(0x60 | (irq & 7))); //slave specific EOI
+        outp(PIC_PORT1, (uint8_t)(0x60 | PIC_SLAVE_IRQ)); //master specific EOI for cascade
+    }
+    else
+        outp(PIC_PORT1, (uint8_t)(0x60 | irq)); //master specific EOI
+}
+
 uint8_t PIC_GetIRQ(void)
 {
     //CLIS();

--- a/USBDDOS/pic.h
+++ b/USBDDOS/pic.h
@@ -21,6 +21,9 @@ extern "C"
 //send end of interrupt. MUST be called in interrupt handler
 void PIC_SendEOI(void);
 
+//send a specific EOI for one IRQ, leaving other in-service IRQs intact
+void PIC_SendSpecificEOI(uint8_t irq);
+
 //get interrupting IRQ. MUST be called in interrupt handler
 uint8_t PIC_GetIRQ(void);
 


### PR DESCRIPTION
# Defer nested hardware IRQs instead of reentering the non-reentrant V86 mode switch

## Problem

A hardware IRQ the driver hooks can fault the whole system with a #GP when
it is taken while another hooked hardware IRQ is still being serviced.

Observed on stock `master` (16-bit Open Watcom build, built-in pseudo-DPMI
monitor, FreeDOS + JEMM386, VCPI), on real hardware (IBM 300GL, PIIX UHCI)
and reproducibly in QEMU. With a serial debug build the monitor prints:

```
Excpetion: 0d, Error: 7468, CS:IP: 00d0:9cf1, FLAGS: 3016
CS:IP: 8e c0 26 8b 47 02 85 c0 75 07 89 f0 e8 26 2f eb
```

The faulting bytes are not in the driver — they are `COMMAND.COM`'s, at a
`mov es, 0x7469` (`8e c0`). That instruction is legal in V86 and only #GPs
in protected mode (error `0x7468` = selector `0x7469 & ~3`). So an
interrupted V86 frame was resumed in protected mode and faulted on its own
ordinary code.

## Root cause

Instrumenting `DPMI_HWIRQHandlerInternal` with a reentrancy counter, the
state at the fault is:

```
... irq=11 depth=0 PM=0    RM=800     (USB controller IRQ, entered from V86/RM)
    irq=12 depth=1 PM=1000 RM=800     (a second IRQ, nested, entered from PM)
```

i.e. while the USB controller IRQ (which entered from V86 through the RMCB
and switched to PM) is mid-service, a second hardware IRQ is delivered to
the **protected-mode IDT** and nests. Servicing it runs
`DPMI_Call_IVT` → `DPMI_CallRealModeINT` → another VCPI PM→V86→PM
round-trip, *while the outer V86→PM round-trip is still in flight*. The
mode-switch uses a single client-state save area and is not reentrant, so
the nested switch clobbers the outer saved frame; when the outer service
returns, it resumes the interrupted V86 code in protected mode → #GP.

(In the report case the nested IRQ is IRQ12, raised because a resident
service wrote to the 8042 from inside the USB ISR while a PS/2 mouse driver
had armed the aux channel. But the defect is general: any hooked hardware
IRQ taken while another is mid-round-trip will do this.)

## Fix

Make the hardware-IRQ path non-reentrant explicitly: in
`DPMI_HWIRQHandlerInternal`, if a hardware IRQ is already in service, the
newly-arrived one is **deferred** instead of entering the mode switch —
mask it at the PIC, send it a specific EOI (so the PIC is not left
in-service and other lines keep working), record it, and return. When the
outer service completes, the deferred lines are unmasked; the source device
has kept its request asserted (or its data latched), so the IRQ re-asserts
and is delivered cleanly in a non-nested context.

A small `PIC_SendSpecificEOI(irq)` helper is added (specific EOI leaving any
other in-service IRQ intact, with the slave/cascade case handled), since
the existing `PIC_SendEOI` is non-specific.

Three files, ~50 lines:
- `DPMI/dpmi_bc.h` — reentrancy guard + deferred-IRQ redelivery in
  `DPMI_HWIRQHandlerInternal`.
- `pic.c` / `pic.h` — `PIC_SendSpecificEOI`.

No change to the normal (non-nested) path.

## Validation

Built clean with Open Watcom and DJGPP.

- Deterministic reproducer (QEMU: a small DOS program arms the 8042 aux
  interrupt and hooks INT 74h, then a `-device usb-mouse` is jiggled so the
  resident driver injects an aux byte from its USB ISR → nested IRQ12):
  **before** = `Excpetion: 0d, Error: 7468` and freeze every time;
  **after** = no exception, the nested IRQ is deferred and redelivered, the
  system continues normally.
- No regression: USB HID enumeration + suspend logic, the
  suspend→retry→resume state machine, and USB mass-storage enumeration +
  capacity probe all behave as before, with zero exceptions.

Happy to attach the reproducer program and a scripted QEMU harness.
